### PR TITLE
Fix: JST-64 - Result with error for batch instead of throw

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run format:check
+npm run format:check && npm run lint

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "test:e2e": "jest --config tests/e2e/jest.config.json tests/e2e/**.spec.ts --runInBand --forceExit",
     "test:e2e:no-goth": "jest tests/e2e/**.spec.ts --testTimeout=180000 --runInBand --forceExit",
     "test:cypress": "cypress run",
-    "lint": "eslint .",
+    "lint": "npm run lint:ts && npm run lint:ts:tests && npm run lint:eslint",
+    "lint:ts": "tsc --project tsconfig.json --noEmit",
+    "lint:ts:tests": "tsc --project tests/tsconfig.json --noEmit",
+    "lint:eslint": "eslint .",
     "format": "prettier -w .",
     "format:check": "prettier -c .",
     "prepare": "husky install"

--- a/src/task/batch.ts
+++ b/src/task/batch.ts
@@ -48,18 +48,19 @@ export class Batch {
     return this;
   }
 
+  /**
+   * Executes the batch of commands added via {@link run} returning result for each of the steps.
+   *
+   * In case any of the commands will fail, the execution of the batch will be interrupted by the Provider.
+   */
   async end(): Promise<Result[]> {
     await this.script.before();
     await sleep(100, true);
     const results = await this.activity.execute(this.script.getExeScriptRequest());
     const allResults: Result[] = [];
     return new Promise((resolve, reject) => {
-      results.on("data", (result) => {
-        allResults.push(result);
-        if (result.result === "Error") {
-          this.script.after(allResults).catch();
-          return reject(`Error: ${result.message}`);
-        }
+      results.on("data", (res) => {
+        allResults.push(res);
       });
 
       results.on("end", () => {

--- a/src/task/work.ts
+++ b/src/task/work.ts
@@ -20,7 +20,7 @@ import { NetworkNode } from "../network";
 export type Worker<InputType = unknown, OutputType = unknown> = (
   ctx: WorkContext,
   data?: InputType,
-) => Promise<OutputType | undefined>;
+) => Promise<OutputType>;
 
 const DEFAULTS = {
   activityPreparingTimeout: 300_000,

--- a/tests/e2e/strategies.spec.ts
+++ b/tests/e2e/strategies.spec.ts
@@ -15,7 +15,7 @@ describe("Strategies", function () {
         logger,
       });
       const data = ["one", "two", "three"];
-      const results = executor.map<string, string>(data, async (ctx, x) => {
+      const results = executor.map<string, string | undefined>(data, async (ctx, x) => {
         const res = await ctx.run(`echo "${x}"`);
         return res.stdout?.trim();
       });
@@ -36,7 +36,7 @@ describe("Strategies", function () {
         logger,
       });
       const data = ["one", "two", "three"];
-      const results = executor.map<string, string>(data, async (ctx, x) => {
+      const results = executor.map<string, string | undefined>(data, async (ctx, x) => {
         const res = await ctx.run(`echo "${x}"`);
         return res.stdout?.trim();
       });
@@ -58,7 +58,7 @@ describe("Strategies", function () {
         logger,
       });
       const data = ["one", "two"];
-      const results = executor.map<string, string>(data, async (ctx, x) => {
+      const results = executor.map<string, string | undefined>(data, async (ctx, x) => {
         const res = await ctx.run(`echo "${x}"`);
         return res.stdout?.trim();
       });
@@ -76,7 +76,7 @@ describe("Strategies", function () {
         logger,
       });
       const data = ["one", "two"];
-      const results = executor.map<string, string>(data, async (ctx, x) => {
+      const results = executor.map<string, string | undefined>(data, async (ctx, x) => {
         const res = await ctx.run(`echo "${x}"`);
         return res.stdout?.trim();
       });

--- a/tests/e2e/tasks.spec.ts
+++ b/tests/e2e/tasks.spec.ts
@@ -116,31 +116,6 @@ describe("Task Executor", function () {
     expect(onEnd).toEqual("END");
   });
 
-  it("should run simple batch script and catch error on stream", async () => {
-    executor = await TaskExecutor.create({
-      package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      logger,
-    });
-    const outputs: string[] = [];
-    let expectedError = "";
-    await executor
-      .run(async (ctx) => {
-        const results = await ctx.beginBatch().run('echo "Hello Golem"').run("invalid_command").endStream();
-        results.on("data", ({ stdout }) => outputs.push(stdout?.trim()));
-        results.on("error", (error) => {
-          expectedError = error.toString();
-        });
-      })
-      .catch((e) => {
-        expect(e).toBeUndefined();
-      });
-    await logger.expectToInclude("Task 1 computed by provider", 5000);
-    expect(outputs[0]).toEqual("Hello Golem");
-    expect(expectedError).toEqual(
-      "Error: ExeScript command exited with code 127. Stdout: undefined. Stderr: sh: 1: invalid_command: not found",
-    );
-  });
-
   it("should run simple batch script and get results as promise", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",

--- a/tests/e2e/tasks.spec.ts
+++ b/tests/e2e/tasks.spec.ts
@@ -140,28 +140,6 @@ describe("Task Executor", function () {
     expect(outputs[2]).toEqual("OK");
   });
 
-  it("should run simple batch script and catch error on promise", async () => {
-    executor = await TaskExecutor.create({
-      package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      logger,
-    });
-    let results;
-    let error;
-    await executor
-      .run(async (ctx) => {
-        results = await ctx
-          .beginBatch()
-          .run('echo "Hello Golem"')
-          .run("invalid_command")
-          .end()
-          .catch((err) => (error = err));
-      })
-      .catch((e) => {
-        expect(e).toBeUndefined();
-      });
-    expect(error).toEqual("Error: ExeScript command exited with code 127");
-  });
-
   it("should run transfer file", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",

--- a/tests/e2e/tasks.spec.ts
+++ b/tests/e2e/tasks.spec.ts
@@ -66,7 +66,7 @@ describe("Task Executor", function () {
       logger,
     });
     const data = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"];
-    const results = executor.map<string, string>(data, async (ctx, x) => {
+    const results = executor.map<string, string | undefined>(data, async (ctx, x) => {
       const res = await ctx.run(`echo "${x}"`);
       return res.stdout?.trim();
     });

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,5 +2,7 @@
   "extends": "../tsconfig.json",
   "include": ["."],
   "exclude": ["./cypress"],
-  "types": ["jest"]
+  "compilerOptions": {
+    "types": ["jest"]
+  }
 }


### PR DESCRIPTION
Fix: JST-64 - When a command executed in a batch fails on the provider, instead of throwing, it returns a 'Error' Result which improves debugging.

In addition, the batch is not retried on a different provider where the broken command could still incur additional cost (repeating the failure).