### PR TITLE
Fixed agreement selection strategy

### DIFF
--- a/src/agreement/strategy.ts
+++ b/src/agreement/strategy.ts
@@ -6,7 +6,7 @@ export const randomAgreementSelector = () => async (candidates: AgreementCandida
 
 /** Selector selecting a random provider from the pool, but giving priority to those who already have a confirmed agreement and deployed activity */
 export const randomAgreementSelectorWithPriorityForExistingOnes = () => async (candidates: AgreementCandidate[]) => {
-  const existingAgreements = candidates.filter((c) => !c.agreement);
+  const existingAgreements = candidates.filter((c) => c.agreement);
   return existingAgreements.length
     ? existingAgreements[Math.floor(Math.random() * existingAgreements.length)]
     : candidates[Math.floor(Math.random() * candidates.length)];


### PR DESCRIPTION
After retests, there was still a bug for the default provider selection strategy with priority for those who already have agreement created. Now it should all work.