### PR TITLE
JST-300: added bundle size validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jest": "^29.6.2",
     "prettier": "^3.0.0",
     "rollup": "^3.26.3",
+    "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-ignore": "^1.0.10",
     "rollup-plugin-polyfill-node": "^0.12.0",
     "rollup-plugin-visualizer": "^5.9.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -7,6 +7,7 @@ import typescript from "@rollup/plugin-typescript";
 import nodePolyfills from "rollup-plugin-polyfill-node";
 import pkg from "./package.json" assert { type: "json" };
 import ignore from "rollup-plugin-ignore";
+import filesize from "rollup-plugin-filesize";
 
 /**
  * Looking for plugins?
@@ -43,6 +44,7 @@ export default [
       json(), // Required because one our dependencies (bottleneck) loads its own 'version.json'
       typescript({ tsconfig: "./tsconfig.json" }),
       terser({ keep_classnames: true }),
+      filesize({ reporter: [sizeValidator, "boxen"] }),
     ],
   },
   // NodeJS
@@ -52,6 +54,12 @@ export default [
       { file: pkg.main, format: "cjs", sourcemap: true },
       { file: pkg.module, format: "es", sourcemap: true },
     ],
-    plugins: [typescript({ tsconfig: "./tsconfig.json" })],
+    plugins: [typescript({ tsconfig: "./tsconfig.json" }), filesize({ reporter: [sizeValidator, "boxen"] })],
   },
 ];
+
+function sizeValidator(options, bundle, { bundleSize }) {
+  if (parseInt(bundleSize) === 0) {
+    throw new Error(`Something went wrong while building. Bundle size = ${bundleSize}`);
+  }
+}


### PR DESCRIPTION
I think the earlier error where we released versions without some files was caused by our temporary workaround where we ended the process with exit code 0 in case of suspension. Now, in each case in which an error occurs, the process will return an exit code !== 0, so there should be no problem and CI will stop entire process. Additionally, I added a validator for the file size.