### PR TITLE
test(examples): add missing composing task example

### DIFF
--- a/examples/docs-examples/examples/composing-tasks/alert-code.mjs
+++ b/examples/docs-examples/examples/composing-tasks/alert-code.mjs
@@ -1,0 +1,23 @@
+import { TaskExecutor } from "@golem-sdk/golem-js";
+(async () => {
+  const executor = await TaskExecutor.create({
+    package: "529f7fdaf1cf46ce3126eb6bbcd3b213c314fe8fe884914f5d1106d4",
+    yagnaOptions: { apiKey: "try_golem" },
+  });
+
+  const result = await executor.run(async (ctx) => {
+    const res = await ctx
+      .beginBatch()
+      .uploadFile("./worker.mjs", "/golem/input/worker.mjs")
+      .run("node /golem/input/worker.mjs > /golem/input/output.txt")
+      .run("cat /golem/input/output.txt")
+      .downloadFile("/golem/input/output.txt", "./output.txt")
+      .endStream();
+
+    for await (const chunk of res) {
+      chunk.index == 2 ? console.log(chunk.stdout) : "";
+    }
+  });
+
+  await executor.end();
+})();

--- a/tests/examples/examples.json
+++ b/tests/examples/examples.json
@@ -14,6 +14,7 @@
   { "cmd": "node", "path": "examples/docs-examples/examples/composing-tasks/single-command.mjs" },
   { "cmd": "node", "path": "examples/docs-examples/examples/composing-tasks/single-command.cjs" },
   { "cmd": "ts-node", "path": "examples/docs-examples/examples/composing-tasks/single-command.ts" },
+  { "cmd": "ts-node", "path": "examples/docs-examples/examples/composing-tasks/alert-code.mjs" },
 
   { "cmd": "node", "path": "examples/docs-examples/examples/executing-tasks/before-each.mjs" },
   { "cmd": "node", "path": "examples/docs-examples/examples/executing-tasks/foreach.mjs" },


### PR DESCRIPTION
https://docs.golem.network/docs/creators/javascript/examples/composing-tasks

The code example at the bottom of the page was missing

<img width="856" alt="image" src="https://github.com/golemfactory/golem-js/assets/33448819/0299a537-b2d9-4df9-b3de-fc9b4b8174ca">
