### PR TITLE
Fix overview.md not being generated properly for docs.

### DIFF
--- a/.docs/typedoc-frontmatter-theme.cjs
+++ b/.docs/typedoc-frontmatter-theme.cjs
@@ -32,7 +32,8 @@ class ModifiedHugoTheme extends HugoTheme {
     return (
       "---\n" +
       Object.entries(yamlVars)
-        .map(([key, value]) => `${key}: ${value}`)
+        .map(([key, value]) => `${key}: "${value}"`)
+
         .join("\n") +
       "\n---\n" +
       contents


### PR DESCRIPTION
Right now on the beta branch, all overview.md files generated using `npm run docs:md` will be empty. This PR fixes it.