### PR TITLE
Fix scheduled nightly tasks not picking up default values from workflow

### DIFF
--- a/.github/workflows/cypress-nightly.yml
+++ b/.github/workflows/cypress-nightly.yml
@@ -25,6 +25,11 @@ on:
 jobs:
   cypress-tests:
     runs-on: goth2
+    env:
+      PROVIDER_VERSION: ${{ github.event.inputs.provider_version || 'v0.12.3' }}
+      REQUESTOR_VERSION: ${{ github.event.inputs.requestor_version || 'v0.12.3' }}
+      PROVIDER_WASI_VERSION: ${{ github.event.inputs.provider_wasi_version || 'v0.2.2' }}
+      PROVIDER_VM_VERSION: ${{ github.event.inputs.provider_vm_version || 'v0.3.0' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,10 +39,10 @@ jobs:
 
       - name: Set up Versions
         run: |
-          echo "PROVIDER_VERSION=${{ github.event.inputs.provider_version }}" >> $GITHUB_ENV
-          echo "REQUESTOR_VERSION=${{ github.event.inputs.requestor_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_WASI_VERSION=${{ github.event.inputs.provider_wasi_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_VM_VERSION=${{ github.event.inputs.provider_vm_version }}" >> $GITHUB_ENV
+          echo "PROVIDER_VERSION=${PROVIDER_VERSION}" >> $GITHUB_ENV
+          echo "REQUESTOR_VERSION=${REQUESTOR_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_WASI_VERSION=${PROVIDER_WASI_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_VM_VERSION=${PROVIDER_VM_VERSION}" >> $GITHUB_ENV
 
       - name: Build the docker containers
         run: |

--- a/.github/workflows/examples-nightly.yml
+++ b/.github/workflows/examples-nightly.yml
@@ -36,6 +36,11 @@ jobs:
   goth-tests:
     runs-on: goth2
     needs: prepare-matrix-master-only
+    env:
+      PROVIDER_VERSION: ${{ github.event.inputs.provider_version || 'v0.12.3' }}
+      REQUESTOR_VERSION: ${{ github.event.inputs.requestor_version || 'v0.12.3' }}
+      PROVIDER_WASI_VERSION: ${{ github.event.inputs.provider_wasi_version || 'v0.2.2' }}
+      PROVIDER_VM_VERSION: ${{ github.event.inputs.provider_vm_version || 'v0.3.0' }}
     strategy:
       matrix: ${{ fromJson(needs.prepare-matrix-master-only.outputs.matrix-json) }}
       fail-fast: false
@@ -48,10 +53,10 @@ jobs:
 
       - name: Set up Versions
         run: |
-          echo "PROVIDER_VERSION=${{ github.event.inputs.provider_version }}" >> $GITHUB_ENV
-          echo "REQUESTOR_VERSION=${{ github.event.inputs.requestor_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_WASI_VERSION=${{ github.event.inputs.provider_wasi_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_VM_VERSION=${{ github.event.inputs.provider_vm_version }}" >> $GITHUB_ENV
+          echo "PROVIDER_VERSION=${PROVIDER_VERSION}" >> $GITHUB_ENV
+          echo "REQUESTOR_VERSION=${REQUESTOR_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_WASI_VERSION=${PROVIDER_WASI_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_VM_VERSION=${PROVIDER_VM_VERSION}" >> $GITHUB_ENV
 
       - name: Build the docker containers
         run: |

--- a/.github/workflows/goth-nightly.yml
+++ b/.github/workflows/goth-nightly.yml
@@ -37,6 +37,11 @@ jobs:
   goth-tests:
     runs-on: goth2
     needs: prepare-matrix-master-only
+    env:
+      PROVIDER_VERSION: ${{ github.event.inputs.provider_version || 'v0.12.3' }}
+      REQUESTOR_VERSION: ${{ github.event.inputs.requestor_version || 'v0.12.3' }}
+      PROVIDER_WASI_VERSION: ${{ github.event.inputs.provider_wasi_version || 'v0.2.2' }}
+      PROVIDER_VM_VERSION: ${{ github.event.inputs.provider_vm_version || 'v0.3.0' }}
     strategy:
       matrix: ${{ fromJson(needs.prepare-matrix-master-only.outputs.matrix-json) }}
       fail-fast: false
@@ -52,10 +57,10 @@ jobs:
 
       - name: Set up Versions
         run: |
-          echo "PROVIDER_VERSION=${{ github.event.inputs.provider_version }}" >> $GITHUB_ENV
-          echo "REQUESTOR_VERSION=${{ github.event.inputs.requestor_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_WASI_VERSION=${{ github.event.inputs.provider_wasi_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_VM_VERSION=${{ github.event.inputs.provider_vm_version }}" >> $GITHUB_ENV
+          echo "PROVIDER_VERSION=${PROVIDER_VERSION}" >> $GITHUB_ENV
+          echo "REQUESTOR_VERSION=${REQUESTOR_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_WASI_VERSION=${PROVIDER_WASI_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_VM_VERSION=${PROVIDER_VM_VERSION}" >> $GITHUB_ENV
 
       - name: Build the docker containers
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,11 @@ jobs:
     name: Run integration and E2E tests
     needs: regular-checks
     runs-on: goth2
+    env:
+      PROVIDER_VERSION: ${{ github.event.inputs.provider_version || 'v0.12.3' }}
+      REQUESTOR_VERSION: ${{ github.event.inputs.requestor_version || 'v0.12.3' }}
+      PROVIDER_WASI_VERSION: ${{ github.event.inputs.provider_wasi_version || 'v0.2.2' }}
+      PROVIDER_VM_VERSION: ${{ github.event.inputs.provider_vm_version || 'v0.3.0' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -77,10 +82,10 @@ jobs:
 
       - name: Set up Versions
         run: |
-          echo "PROVIDER_VERSION=${{ github.event.inputs.provider_version }}" >> $GITHUB_ENV
-          echo "REQUESTOR_VERSION=${{ github.event.inputs.requestor_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_WASI_VERSION=${{ github.event.inputs.provider_wasi_version }}" >> $GITHUB_ENV
-          echo "PROVIDER_VM_VERSION=${{ github.event.inputs.provider_vm_version }}" >> $GITHUB_ENV
+          echo "PROVIDER_VERSION=${PROVIDER_VERSION}" >> $GITHUB_ENV
+          echo "REQUESTOR_VERSION=${REQUESTOR_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_WASI_VERSION=${PROVIDER_WASI_VERSION}" >> $GITHUB_ENV
+          echo "PROVIDER_VM_VERSION=${PROVIDER_VM_VERSION}" >> $GITHUB_ENV
 
       - name: Build the docker containers
         run: |


### PR DESCRIPTION
The previous workflows only used default values for manual triggers, but nightly automated tests didn't use them thus the builds failed. This PR uses either values from the manual triggered workflow or else it defaults to new hardcoded values.