### PR TITLE
maxTaskRetries validation

### DIFF
--- a/src/executor/config.ts
+++ b/src/executor/config.ts
@@ -52,7 +52,12 @@ export class ExecutorConfig {
     Object.keys(options).forEach((key) => (this[key] = options[key]));
     this.activityExecuteTimeout = options.activityExecuteTimeout || options.taskTimeout;
     const apiKey = options?.yagnaOptions?.apiKey || processEnv.env.YAGNA_APPKEY;
-    if (!apiKey) throw new Error("Api key not defined");
+    if (!apiKey) {
+      throw new Error("Api key not defined");
+    }
+    if (options.maxTaskRetries && options.maxTaskRetries < 0) {
+      throw new Error("The maxTaskRetries parameter cannot be less than zero");
+    }
     this.yagnaOptions = {
       apiKey,
       basePath: options.yagnaOptions?.basePath || processEnv.env.YAGNA_API_URL || DEFAULTS.basePath,

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -47,6 +47,9 @@ export class Task<OutputType = unknown> implements QueueableTask {
     this.timeout = options?.timeout ?? DEFAULTS.TIMEOUT;
     this.maxRetries = options?.maxRetries ?? DEFAULTS.MAX_RETRIES;
     this.activityReadySetupFunctions = options?.activityReadySetupFunctions ?? [];
+    if (this.maxRetries < 0) {
+      throw new Error("The maxRetries parameter cannot be less than zero");
+    }
   }
 
   onStateChange(listener: (state: TaskState) => void) {

--- a/tests/e2e/tasks.spec.ts
+++ b/tests/e2e/tasks.spec.ts
@@ -192,4 +192,26 @@ describe("Task Executor", function () {
     expect(logger.logs).toMatch(/Agreement confirmed by provider/);
     expect(logger.logs).toMatch(/Activity .* created/);
   });
+
+  it("should not retry the task if maxTaskRetries is zero", async () => {
+    executor = await TaskExecutor.create({
+      package: "golem/alpine:latest",
+      logger,
+      maxTaskRetries: 0,
+    });
+    executor.onActivityReady(async (ctx) => Promise.reject("Error"));
+    await executor.run(async (ctx) => ctx.run("echo 'Hello World'"));
+    expect(logger.logs).not.toContain("Trying to redo the task");
+  });
+
+  it("should not retry the task if taskRetries is zero", async () => {
+    executor = await TaskExecutor.create({
+      package: "golem/alpine:latest",
+      logger,
+      maxTaskRetries: 7,
+    });
+    executor.onActivityReady(async (ctx) => Promise.reject("Error"));
+    await executor.run(async (ctx) => ctx.run("echo 'Hello World'"), { maxRetries: 0 });
+    expect(logger.logs).not.toContain("Trying to redo the task");
+  });
 });

--- a/tests/e2e/tasks.spec.ts
+++ b/tests/e2e/tasks.spec.ts
@@ -199,8 +199,12 @@ describe("Task Executor", function () {
       logger,
       maxTaskRetries: 0,
     });
-    executor.onActivityReady(async (ctx) => Promise.reject("Error"));
-    await executor.run(async (ctx) => ctx.run("echo 'Hello World'"));
+    try {
+      executor.onActivityReady(async (ctx) => Promise.reject("Error"));
+      await executor.run(async (ctx) => console.log((await ctx.run("echo 'Hello World'")).stdout));
+    } catch (error) {
+      await executor.shutdown();
+    }
     expect(logger.logs).not.toContain("Trying to redo the task");
   });
 
@@ -210,8 +214,12 @@ describe("Task Executor", function () {
       logger,
       maxTaskRetries: 7,
     });
-    executor.onActivityReady(async (ctx) => Promise.reject("Error"));
-    await executor.run(async (ctx) => ctx.run("echo 'Hello World'"), { maxRetries: 0 });
+    try {
+      executor.onActivityReady(async (ctx) => Promise.reject("Error"));
+      await executor.run(async (ctx) => console.log((await ctx.run("echo 'Hello World'")).stdout), { maxRetries: 0 });
+    } catch (error) {
+      await executor.shutdown();
+    }
     expect(logger.logs).not.toContain("Trying to redo the task");
   });
 });

--- a/tests/unit/tasks_service.test.ts
+++ b/tests/unit/tasks_service.test.ts
@@ -86,6 +86,35 @@ describe("Task Service", () => {
     await service.end();
   });
 
+  it("should not retry task if it failed and maxRetries is zero", async () => {
+    const worker = async (ctx: WorkContext) => ctx.run("some_shell_command");
+    const task = new Task("1", worker, { maxRetries: 0 });
+    queue.addToEnd(task);
+    activityMock.setExpectedErrors([new Error(), new Error(), new Error(), new Error(), new Error()]);
+    const service = new TaskService(
+      new YagnaMock().getApi(),
+      queue,
+      agreementPoolServiceMock,
+      paymentServiceMock,
+      networkServiceMock,
+      {
+        logger,
+        taskRunningInterval: 100,
+        activityStateCheckingInterval: 100,
+      },
+    );
+    service.run().catch((e) => console.error(e));
+    await logger.expectToInclude("Task 1 has been rejected!", 700);
+    await service.end();
+  });
+
+  it("should throw an error if maxRetries is less then zero", async () => {
+    const worker = async (ctx: WorkContext) => Promise.resolve(true);
+    expect(() => new Task("1", worker, { maxRetries: -1 })).toThrow(
+      "The maxRetries parameter cannot be less than zero",
+    );
+  });
+
   it("should reject task by user", async () => {
     const worker = async (ctx: WorkContext) => {
       const result = await ctx.run("some_shell_command");

--- a/tests/unit/tasks_service.test.ts
+++ b/tests/unit/tasks_service.test.ts
@@ -104,7 +104,8 @@ describe("Task Service", () => {
       },
     );
     service.run().catch((e) => console.error(e));
-    await logger.expectToInclude("Task 1 has been rejected!", 700);
+    await logger.expectToNotMatch(/Trying to redo the task/, 100);
+    await logger.expectToInclude("Task 1 has been rejected!", 100);
     await service.end();
   });
 


### PR DESCRIPTION
The bug with `maxTaskRetries: 0`  does not exist, it was fixed somewhere earlier... I only added unit tests and e2e tests that verify this. Additionally, I added validation of the maxTaskRetries parameter. Now throws an error for a value less than zero.