### PR TITLE
Add requestor / provider versions to workflow name to make it easier to see #681

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,4 +189,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
-run-name: "${{ github.workflow }} - Requestor: ${{ env.REQUESTOR_VERSION }}, Provider: ${{ env.PROVIDER_VERSION }}, WASI: ${{ env.PROVIDER_WASI_VERSION }}, VM: ${{ env.PROVIDER_VM_VERSION }}"
+run-name: "${{ github.workflow }} - Requestor: ${{ github.event.inputs.requestor_version }}, Provider: ${{ github.event.inputs.provider_version }}, WASI: ${{ github.event.inputs.provider_wasi_version }}, VM: ${{ github.event.inputs.provider_vm_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: Release Pipeline
-run-name: "${{ github.workflow }} - Requestor: ${{ env.REQUESTOR_VERSION }}, Provider: ${{ env.PROVIDER_VERSION }}, WASI: ${{ env.PROVIDER_WASI_VERSION }}, VM: ${{ env.PROVIDER_VM_VERSION }}"
 
 on:
   push:
@@ -190,3 +189,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+run-name: "${{ github.workflow }} - Requestor: ${{ env.REQUESTOR_VERSION }}, Provider: ${{ env.PROVIDER_VERSION }}, WASI: ${{ env.PROVIDER_WASI_VERSION }}, VM: ${{ env.PROVIDER_VM_VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release Pipeline
+run-name: "${{ github.workflow }} - Requestor: ${{ env.REQUESTOR_VERSION }}, Provider: ${{ env.PROVIDER_VERSION }}, WASI: ${{ env.PROVIDER_WASI_VERSION }}, VM: ${{ env.PROVIDER_VM_VERSION }}"
 
 on:
   push:


### PR DESCRIPTION
It's unfortunately not possible to use ENV values to name a run, so automated triggers of the release pipeline might not have the version defined in the title, but the workflow should still work.