### PR TITLE
fix(activity): issues with starting an activity are now possible to handle by users

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,20 +1,4 @@
 {
   "preset": "ts-jest",
-  "testEnvironment": "node",
-  "reporters": [
-    [
-      "jest-junit",
-      {
-        "outputDirectory": "reports",
-        "outputName": "general-report.xml"
-      }
-    ],
-    [
-      "github-actions",
-      {
-        "silent": false
-      }
-    ],
-    "summary"
-  ]
+  "testEnvironment": "node"
 }

--- a/src/activity/factory.test.ts
+++ b/src/activity/factory.test.ts
@@ -1,0 +1,33 @@
+import { ActivityFactory } from "./factory";
+import { Agreement } from "../agreement";
+import { anything, imock, instance, mock, when } from "@johanblumenberg/ts-mockito";
+import { YagnaApi } from "../utils";
+import { RequestorControlApi } from "ya-ts-client/dist/ya-activity/api";
+import { RequestorStateApi } from "ya-ts-client/dist/ya-activity/src/api/requestor-state-api";
+
+describe("Activity Factory", () => {
+  describe("Creating activities", () => {
+    describe("Negative cases", () => {
+      it("Correctly passes the exception thrown during activity creation to the user", async () => {
+        const agreement = mock(Agreement);
+        const yagnaAPi = imock<YagnaApi>();
+
+        const controlApi = mock(RequestorControlApi);
+        const stateApi = mock(RequestorStateApi);
+
+        const components = {
+          control: instance(controlApi),
+          state: instance(stateApi),
+        };
+
+        when(yagnaAPi.activity).thenReturn(components);
+
+        when(controlApi.createActivity(anything())).thenReject("Foo");
+
+        const factory = new ActivityFactory(instance(agreement), instance(yagnaAPi));
+
+        await expect(() => factory.create()).rejects.toThrow("Foo");
+      });
+    });
+  });
+});

--- a/src/activity/factory.ts
+++ b/src/activity/factory.ts
@@ -12,13 +12,6 @@ import { Agreement } from "../agreement";
 export class ActivityFactory {
   private readonly options: ActivityConfig;
 
-  /**
-   * Creating ActivityFactory
-   *
-   * @param agreement - {@link Agreement}
-   * @param yagnaApi - {@link YagnaApi}
-   * @param options - {@link ActivityOptions}
-   */
   constructor(
     private readonly agreement: Agreement,
     private readonly yagnaApi: YagnaApi,
@@ -27,19 +20,12 @@ export class ActivityFactory {
     this.options = new ActivityConfig(options);
   }
 
-  /**
-   * Create activity for given agreement ID
-   *
-   * @param secure defines if activity will be secure type
-   * @return {@link Activity}
-   * @throws {@link Error} if activity could not be created
-   */
   public async create(secure = false): Promise<Activity> {
     try {
       if (secure) {
         throw new Error("Not implemented");
       }
-      return this.createActivity();
+      return await this.createActivity();
     } catch (error) {
       const msg = `Unable to create activity: ${error?.response?.data?.message || error}`;
       this.options.logger?.error(msg);
@@ -49,9 +35,12 @@ export class ActivityFactory {
 
   private async createActivity(): Promise<Activity> {
     const { data } = await this.yagnaApi.activity.control.createActivity({ agreementId: this.agreement.id });
+
     const id = typeof data == "string" ? data : data.activityId;
+
     this.options.logger?.debug(`Activity ${id} created`);
     this.options.eventTarget?.dispatchEvent(new Events.ActivityCreated({ id, agreementId: this.agreement.id }));
+
     return new Activity(id, this.agreement, this.yagnaApi, this.options);
   }
 }

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -40,21 +40,40 @@ export class TaskStarted extends BaseEvent<{
   providerId: string;
   providerName: string;
 }> {}
+
+/**
+ * Represents the situation in which running the task failed for some reason, but it will be retried
+ */
 export class TaskRedone extends BaseEvent<{
   id: string;
   agreementId: string;
-  activityId: string;
   providerId: string;
   providerName: string;
   retriesCount: number;
+  /**
+   * The activity that was involved
+   *
+   * This might be not set when there was an issue with starting the activity on the provider
+   */
+  activityId?: string;
   reason?: string;
 }> {}
+
+/**
+ * Represents the situation where all attempts to execute the task have been unsuccessful and no further processing
+ * will be conducted.
+ */
 export class TaskRejected extends BaseEvent<{
   id: string;
   agreementId: string;
-  activityId: string;
   providerId: string;
   providerName: string;
+  /**
+   * The activity that was involved when the rejection took place
+   *
+   * This might be not set when there was an issue with starting the activity on the provider
+   */
+  activityId?: string;
   reason?: string;
 }> {}
 export class TaskFinished extends BaseEvent<{ id: string }> {}

--- a/src/task/service.ts
+++ b/src/task/service.ts
@@ -57,7 +57,9 @@ export class TaskService {
         await sleep(this.options.taskRunningInterval, true);
         continue;
       }
-      this.startTask(task).catch((error) => this.isRunning && this.logger?.error(error));
+      this.startTask(task).catch(
+        (error) => this.isRunning && this.logger?.error(`Issue with starting a task on Golem ${error}`),
+      );
     }
   }
 
@@ -76,9 +78,11 @@ export class TaskService {
     ++this.activeTasksCount;
 
     const agreement = await this.agreementPoolService.getAgreement();
-    const activity = await this.getOrCreateActivity(agreement);
+    let activity: Activity | undefined;
 
     try {
+      activity = await this.getOrCreateActivity(agreement);
+
       this.options.eventTarget?.dispatchEvent(
         new Events.TaskStarted({
           id: task.id,
@@ -96,6 +100,7 @@ export class TaskService {
       const activityReadySetupFunctions = task.getActivityReadySetupFunctions();
       const worker = task.getWorker();
       const networkNode = await this.networkService?.addNode(agreement.provider.id);
+
       const ctx = new WorkContext(activity, {
         activityReadySetupFunctions: this.activitySetupDone.has(activity.id) ? [] : activityReadySetupFunctions,
         provider: agreement.provider,
@@ -105,25 +110,31 @@ export class TaskService {
         activityPreparingTimeout: this.options.activityPreparingTimeout,
         activityStateCheckingInterval: this.options.activityStateCheckingInterval,
       });
+
       await ctx.before();
+
       if (activityReadySetupFunctions.length && !this.activitySetupDone.has(activity.id)) {
         this.activitySetupDone.add(activity.id);
         this.logger?.debug(`Activity setup completed in activity ${activity.id}`);
       }
+
       const results = await worker(ctx);
       task.stop(results);
+
       this.options.eventTarget?.dispatchEvent(new Events.TaskFinished({ id: task.id }));
       this.logger?.info(`Task ${task.id} computed by provider ${agreement.provider.name}.`);
     } catch (error) {
       task.stop(undefined, error);
-      const reason = error?.response?.data?.message || error.message || error.toString();
+
+      const reason = error.message || error.toString();
       this.logger?.warn(`Starting task failed due to this issue: ${reason}`);
+
       if (task.isRetry() && this.isRunning) {
         this.tasksQueue.addToBegin(task);
         this.options.eventTarget?.dispatchEvent(
           new Events.TaskRedone({
             id: task.id,
-            activityId: activity.id,
+            activityId: activity?.id,
             agreementId: agreement.id,
             providerId: agreement.provider.id,
             providerName: agreement.provider.name,
@@ -139,7 +150,7 @@ export class TaskService {
           new Events.TaskRejected({
             id: task.id,
             agreementId: agreement.id,
-            activityId: activity.id,
+            activityId: activity?.id,
             providerId: agreement.provider.id,
             providerName: agreement.provider.name,
             reason,
@@ -148,12 +159,19 @@ export class TaskService {
         task.cleanup();
         throw new Error(`Task ${task.id} has been rejected! ${reason}`);
       }
-      await activity.stop().catch((actError) => this.logger?.debug(actError));
-      this.activities.delete(agreement.id);
+
+      if (activity) {
+        await this.stopActivity(activity, agreement);
+      }
     } finally {
       --this.activeTasksCount;
+      await this.agreementPoolService.releaseAgreement(agreement.id, task.isDone()).catch((e) => this.logger?.debug(e));
     }
-    await this.agreementPoolService.releaseAgreement(agreement.id, task.isDone()).catch((e) => this.logger?.debug(e));
+  }
+
+  private async stopActivity(activity: Activity, agreement: Agreement) {
+    await activity?.stop();
+    this.activities.delete(agreement.id);
   }
 
   private async getOrCreateActivity(agreement: Agreement) {


### PR DESCRIPTION
Previously, when the provider failed to start the activity, this was not easily visible for the requestor. Now the issues with creating the activity on the provider are visible to the user and lead to proper activity and agreement termination. However, if the activity could not be created because the provider is a faulty one, the agreement is still not terminated - at least not by the task-executor.