### PR TITLE
Fix incorrect rollup configuration for eventsource

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -27,7 +27,7 @@ export default [
       format: "es",
     },
     plugins: [
-      ignore(["tmp", "pino", "eventsource"]),
+      ignore(["tmp", "pino"]),
       alias({
         entries: [
           { find: "stream", replacement: "stream-browserify" },


### PR DESCRIPTION
The spawn method did not work in the browser because we ignored the eventsource library in the build