### PR TITLE
JST-652: Implement coding conventions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,7 @@
       {
         "selector": ["memberLike", "function"],
         "format": ["camelCase"],
-        "leadingUnderscore": "allow",
+        "leadingUnderscore": "forbid",
         "filter": {
           "regex": "golem.*", // ProposalProperties like 'golem.com.payment.debit-notes.accept-timeout?'
           "match": false

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,13 +21,17 @@
       {
         "selector": "variable",
         "format": ["camelCase", "UPPER_CASE"],
-        "leadingUnderscore": "allow",
-        "trailingUnderscore": "allow"
+        "leadingUnderscore": "forbid",
+        "trailingUnderscore": "forbid"
       },
       {
-        "selector": ["typeMethod", "function"],
+        "selector": ["memberLike", "function"],
         "format": ["camelCase"],
-        "leadingUnderscore": "forbid"
+        "leadingUnderscore": "allow",
+        "filter": {
+          "regex": "golem.*", // ProposalProperties like 'golem.com.payment.debit-notes.accept-timeout?'
+          "match": false
+        }
       },
       {
         "selector": "typeLike",

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,36 @@
       {
         "checkLoops": false
       }
+    ],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "import",
+        "format": ["camelCase", "PascalCase"]
+      },
+      {
+        "selector": "variable",
+        "format": ["camelCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": ["typeMethod", "function"],
+        "format": ["camelCase"],
+        "leadingUnderscore": "forbid"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"]
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"]
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null // We have too many varrying cases like YAGNA_APPKEY, Authorization, golem.com.scheme.payu.payment-timeout-sec? which break this constantly
+      }
     ]
   },
   "overrides": [

--- a/examples/blender/blender.ts
+++ b/examples/blender/blender.ts
@@ -1,9 +1,9 @@
 import { TaskExecutor } from "@golem-sdk/golem-js";
 import { program } from "commander";
 import { fileURLToPath } from "url";
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const DIR_NAME = fileURLToPath(new URL(".", import.meta.url));
 
-const blender_params = (frame) => ({
+const blenderParams = (frame) => ({
   scene_file: "/golem/resource/scene.blend",
   resolution: [400, 300],
   use_compositing: false,
@@ -32,19 +32,16 @@ async function main(subnetTag: string, driver?: string, network?: string, debug?
 
   try {
     executor.onActivityReady(async (ctx) => {
-      await ctx.uploadFile(`${__dirname}/cubes.blend`, "/golem/resource/scene.blend");
+      await ctx.uploadFile(`${DIR_NAME}/cubes.blend`, "/golem/resource/scene.blend");
     });
 
     const futureResults = [0, 10, 20, 30, 40, 50].map((frame) =>
       executor.run(async (ctx) => {
         const result = await ctx
           .beginBatch()
-          .uploadJson(blender_params(frame), "/golem/work/params.json")
+          .uploadJson(blenderParams(frame), "/golem/work/params.json")
           .run("/golem/entrypoints/run-blender.sh")
-          .downloadFile(
-            `/golem/output/out${frame?.toString().padStart(4, "0")}.png`,
-            `${__dirname}/output_${frame}.png`,
-          )
+          .downloadFile(`/golem/output/out${frame?.toString().padStart(4, "0")}.png`, `${DIR_NAME}/output_${frame}.png`)
           .end();
         return result?.length ? `output_${frame}.png` : "";
       }),

--- a/examples/external-request/request.ts
+++ b/examples/external-request/request.ts
@@ -1,16 +1,16 @@
 import { TaskExecutor } from "@golem-sdk/golem-js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const DIR_NAME = fileURLToPath(new URL(".", import.meta.url));
 
 (async function main() {
   const executor = await TaskExecutor.create({
-    manifest: Buffer.from(readFileSync(`${__dirname}/manifest.json`, "utf-8")).toString("base64"),
+    manifest: Buffer.from(readFileSync(`${DIR_NAME}/manifest.json`, "utf-8")).toString("base64"),
     /**
      * Uncomment this if you have a certificate and a signed manifest
      */
-    // manifestSig: readFileSync(`${__dirname}/manifest.json.base64.sign.sha256.base64`, "utf-8"),
-    // manifestCert: readFileSync(`${__dirname}/golem-manifest.crt.pem.base64`, "utf-8"),
+    // manifestSig: readFileSync(`${DIR_NAME}/manifest.json.base64.sign.sha256.base64`, "utf-8"),
+    // manifestCert: readFileSync(`${DIR_NAME}/golem-manifest.crt.pem.base64`, "utf-8"),
     // manifestSigAlgorithm: "sha256",
     capabilities: ["inet", "manifest-support"],
   });

--- a/examples/fibonacci/fibo.js
+++ b/examples/fibonacci/fibo.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 
-function fibo_loop(n) {
+function fiboLoop(n) {
   let a = 1,
     b = 0;
   while (n >= 0) {
@@ -10,30 +10,30 @@ function fibo_loop(n) {
   return b;
 }
 
-function fibo_recur(n) {
-  return n > 1 ? fibo_recur(n - 1) + fibo_recur(n - 2) : 1;
+function fiboRecur(n) {
+  return n > 1 ? fiboRecur(n - 1) + fiboRecur(n - 2) : 1;
 }
 
-function fibo_memo(n, memo) {
+function fiboMemo(n, memo) {
   memo = memo || {};
   if (memo[n]) return memo[n];
   if (n <= 1) return 1;
-  return (memo[n] = fibo_memo(n - 1, memo) + fibo_memo(n - 2, memo));
+  return (memo[n] = fiboMemo(n - 1, memo) + fiboMemo(n - 2, memo));
 }
 
 function benchmark(fn, n, type) {
-  const time_start = process.hrtime();
+  const timeStart = process.hrtime();
   const result = fn(n);
-  const time_stop = process.hrtime(time_start);
-  return { type, result, time: parseFloat(time_stop.join(".")) };
+  const timeSTop = process.hrtime(timeStart);
+  return { type, result, time: parseFloat(timeSTop.join(".")) };
 }
 
 const n = process.argv[2] || 1;
 
 const results = [
-  benchmark(fibo_loop, n, "loop"),
-  benchmark(fibo_recur, n, "recursion"),
-  benchmark(fibo_memo, n, "memoization"),
+  benchmark(fiboLoop, n, "loop"),
+  benchmark(fiboRecur, n, "recursion"),
+  benchmark(fiboMemo, n, "memoization"),
 ].sort((a, b) => a.time - b.time);
 
 console.table(results);

--- a/src/activity/results.ts
+++ b/src/activity/results.ts
@@ -65,6 +65,8 @@ export class Result<TData = any> implements ResultData<TData> {
 }
 
 export interface StreamingBatchEvent {
+  // Reason for disable: That's something what yagna returns from its api
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   batch_id: string;
   index: number;
   timestamp: string;
@@ -83,6 +85,8 @@ interface RuntimeEventStarted {
 }
 
 interface RuntimeEventFinished {
+  // Reason for disable: That's something what yagna returns from its api
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   return_code: number;
   message: string;
 }

--- a/src/activity/service.test.ts
+++ b/src/activity/service.test.ts
@@ -12,7 +12,7 @@ describe("Activity Pool Service", () => {
   describe("run()", () => {
     it("should start service", async () => {
       await activityService.run();
-      expect(activityService.isRunning).toEqual(true);
+      expect(activityService.isRunning()).toEqual(true);
       await activityService.end();
     });
   });
@@ -20,7 +20,7 @@ describe("Activity Pool Service", () => {
     it("should stop service", async () => {
       await activityService.run();
       await activityService.end();
-      expect(activityService.isRunning).toEqual(false);
+      expect(activityService.isRunning()).toEqual(false);
     });
   });
   describe("getActivity()", () => {

--- a/src/activity/service.ts
+++ b/src/activity/service.ts
@@ -15,7 +15,7 @@ interface ActivityServiceOptions extends ActivityOptions {}
 export class ActivityPoolService {
   private logger: Logger;
   private pool: Activity[] = [];
-  private _isRunning = false;
+  private runningState = false;
 
   constructor(
     private yagnaApi: YagnaApi,
@@ -30,19 +30,19 @@ export class ActivityPoolService {
    * Start ActivityPoolService
    */
   async run() {
-    this._isRunning = true;
+    this.runningState = true;
     this.logger.debug("Activity Pool Service has started");
   }
 
-  get isRunning() {
-    return this._isRunning;
+  isRunning() {
+    return this.runningState;
   }
 
   /**
    * Get an activity from the pool of available ones or create a new one
    */
   async getActivity(): Promise<Activity> {
-    if (!this._isRunning) {
+    if (!this.runningState) {
       throw new GolemError("Unable to get activity. Activity service is not running");
     }
     return this.pool.shift() || (await this.createActivity());
@@ -70,7 +70,7 @@ export class ActivityPoolService {
    */
   async end() {
     await Promise.all(this.pool.map((activity) => activity.stop().catch((e) => this.logger.warn(e))));
-    this._isRunning = false;
+    this.runningState = false;
     this.logger.debug("Activity Pool Service has been stopped");
   }
 

--- a/src/activity/service.ts
+++ b/src/activity/service.ts
@@ -16,6 +16,7 @@ export class ActivityPoolService {
   private logger: Logger;
   private pool: Activity[] = [];
   private _isRunning = false;
+
   constructor(
     private yagnaApi: YagnaApi,
     private agreementService: AgreementPoolService,

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -6,7 +6,7 @@ import { RequireAtLeastOne } from "../utils/types";
 /**
  * Global Event Type with which all API events will be emitted. It should be used on all listeners that would like to handle events.
  */
-export const EventType = "GolemEvent";
+export const EVENT_TYPE = "GolemEvent";
 
 // Temporary polyfill
 // It is now implemented natively only for nodejs 19 and newest browsers
@@ -26,7 +26,7 @@ class CustomEvent<DataType> extends Event {
 
 export abstract class BaseEvent<DataType> extends CustomEvent<DataType> {
   constructor(data?: DataType) {
-    super(EventType, { detail: data });
+    super(EVENT_TYPE, { detail: data });
   }
 }
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,2 +1,2 @@
 export * as Events from "./events";
-export { EventType, BaseEvent } from "./events";
+export { EVENT_TYPE, BaseEvent } from "./events";

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -1,23 +1,23 @@
 import { Package, PackageOptions } from "../package";
 import { MarketService } from "../market";
 import { AgreementPoolService } from "../agreement";
-import { Task, TaskQueue, TaskService, Worker, TaskOptions } from "../task";
-import { PaymentService, PaymentOptions } from "../payment";
+import { Task, TaskOptions, TaskQueue, TaskService, Worker } from "../task";
+import { PaymentOptions, PaymentService } from "../payment";
 import { NetworkService } from "../network";
-import { sleep, Logger, LogLevel, runtimeContextChecker, Yagna } from "../utils";
-import { StorageProvider, GftpStorageProvider, NullStorageProvider, WebSocketBrowserStorageProvider } from "../storage";
+import { Logger, LogLevel, runtimeContextChecker, sleep, Yagna } from "../utils";
+import { GftpStorageProvider, NullStorageProvider, StorageProvider, WebSocketBrowserStorageProvider } from "../storage";
 import { ExecutorConfig } from "./config";
 import { Events } from "../events";
 import { StatsService } from "../stats/service";
 import { TaskServiceOptions } from "../task/service";
 import { NetworkServiceOptions } from "../network/service";
 import { AgreementServiceOptions } from "../agreement/service";
-import { WorkOptions } from "../task/work";
 import { MarketOptions } from "../market/service";
 import { RequireAtLeastOne } from "../utils/types";
 import { TaskExecutorEventsDict } from "./events";
 import { EventEmitter } from "eventemitter3";
 import { GolemError } from "../error/golem-error";
+import { WorkOptions } from "../task/work";
 
 const terminatingSignals = ["SIGINT", "SIGTERM", "SIGBREAK", "SIGHUP"];
 
@@ -80,7 +80,7 @@ export type ExecutorOptions = {
   PaymentOptions &
   NetworkServiceOptions &
   AgreementServiceOptions &
-  Omit<WorkOptions, "isRunning">;
+  WorkOptions;
 
 /**
  * Contains information needed to start executor, if string the imageHash is required, otherwise it should be a type of {@link ExecutorOptions}

--- a/src/golem_network/golem_network.ts
+++ b/src/golem_network/golem_network.ts
@@ -60,7 +60,7 @@ export class GolemNetwork {
    * Close the connection to the Yagna service and cancel all running jobs.
    */
   public async close() {
-    const pendingJobs = Array.from(this.jobs.values()).filter((job) => job.isRunning);
+    const pendingJobs = Array.from(this.jobs.values()).filter((job) => job.isRunning());
     await Promise.allSettled(pendingJobs.map((job) => job.cancel()));
     await this.yagna.end();
   }

--- a/src/golem_network/golem_network.ts
+++ b/src/golem_network/golem_network.ts
@@ -5,7 +5,7 @@ import { Yagna, YagnaApi } from "../utils";
 import { RunJobOptions } from "../job/job";
 import { GolemError } from "../error/golem-error";
 
-type GolemNetworkConfig = Partial<RunJobOptions> & { yagna?: YagnaOptions };
+export type GolemNetworkConfig = Partial<RunJobOptions> & { yagna?: YagnaOptions };
 
 /**
  * The Golem Network class provides a high-level API for running jobs on the Golem Network.
@@ -13,8 +13,6 @@ type GolemNetworkConfig = Partial<RunJobOptions> & { yagna?: YagnaOptions };
 export class GolemNetwork {
   private yagna: Yagna;
   private api: YagnaApi | null = null;
-
-  private initializedState = false;
 
   private jobs = new Map<string, Job>();
 
@@ -26,14 +24,12 @@ export class GolemNetwork {
   }
 
   public isInitialized() {
-    return this.initializedState;
+    return this.api !== null;
   }
 
   public async init() {
     await this.yagna.connect();
     this.api = this.yagna.getApi();
-
-    this.initializedState = true;
   }
 
   /**
@@ -65,11 +61,11 @@ export class GolemNetwork {
     const pendingJobs = Array.from(this.jobs.values()).filter((job) => job.isRunning());
     await Promise.allSettled(pendingJobs.map((job) => job.cancel()));
     await this.yagna.end();
-    this.initializedState = false;
+    this.api = null;
   }
 
   private checkInitialization() {
-    if (!this.initializedState || this.api === null) {
+    if (!this.isInitialized()) {
       throw new GolemError("GolemNetwork not initialized, please run init() first");
     }
   }

--- a/src/golem_network/index.ts
+++ b/src/golem_network/index.ts
@@ -1,1 +1,1 @@
-export { GolemNetwork } from "./golem_network";
+export { GolemNetwork, GolemNetworkConfig } from "./golem_network";

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,5 +25,5 @@ export {
 } from "./utils";
 export { Yagna, YagnaOptions } from "./utils/yagna/yagna";
 export { Job, JobState } from "./job";
-export { GolemNetwork } from "./golem_network";
+export * from "./golem_network";
 export { Worker, WorkContext } from "./task";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { ProposalFilters, ProposalFilter, MarketHelpers, MarketService, MarketOp
 export { Package, PackageOptions, AllPackageOptions } from "./package";
 export { PaymentFilters, PaymentService, PaymentOptions } from "./payment";
 export { NetworkService, NetworkServiceOptions } from "./network";
-export { Events, BaseEvent, EventType } from "./events";
+export { Events, BaseEvent, EVENT_TYPE } from "./events";
 export {
   Logger,
   LogLevel,

--- a/src/job/job.ts
+++ b/src/job/job.ts
@@ -122,7 +122,7 @@ export class Job<Output = unknown> {
     // reset abort controller
     this.abortController = new AbortController();
 
-    this._runWork({
+    this.runWork({
       worker: workOnGolem,
       marketService,
       agreementService,
@@ -149,7 +149,7 @@ export class Job<Output = unknown> {
       });
   }
 
-  private async _runWork({
+  private async runWork({
     worker,
     marketService,
     agreementService,
@@ -190,7 +190,7 @@ export class Job<Output = unknown> {
     const activity = await Activity.create(agreement, this.yagnaApi, options.activity);
 
     const storageProvider =
-      this.defaultOptions.work?.storageProvider || options.work?.storageProvider || this._getDefaultStorageProvider();
+      this.defaultOptions.work?.storageProvider || options.work?.storageProvider || this.getDefaultStorageProvider();
 
     const workContext = new WorkContext(activity, {
       provider: agreement.provider,
@@ -218,7 +218,7 @@ export class Job<Output = unknown> {
     return worker(workContext);
   }
 
-  private _getDefaultStorageProvider(): StorageProvider {
+  private getDefaultStorageProvider(): StorageProvider {
     if (runtimeContextChecker.isNode) {
       return new GftpStorageProvider();
     }

--- a/src/market/demand.ts
+++ b/src/market/demand.ts
@@ -97,7 +97,7 @@ export interface DemandOptions {
  * Event type with which all offers and proposals coming from the market will be emitted.
  * @hidden
  */
-export const DemandEventType = "ProposalReceived";
+export const DEMAND_EVENT_TYPE = "ProposalReceived";
 
 /**
  * Demand module - an object which can be considered an "open" or public Demand, as it is not directed at a specific Provider, but rather is sent to the market so that the matching mechanism implementation can associate relevant Offers.
@@ -206,7 +206,7 @@ export class Demand extends EventTarget {
             this.demandRequest,
             this.options.eventTarget,
           );
-          this.dispatchEvent(new DemandEvent(DemandEventType, proposal));
+          this.dispatchEvent(new DemandEvent(DEMAND_EVENT_TYPE, proposal));
           this.options.eventTarget?.dispatchEvent(
             new Events.ProposalReceived({
               id: proposal.id,
@@ -224,7 +224,7 @@ export class Demand extends EventTarget {
           if (error.code === "ECONNREFUSED" || error.response?.status === 404) {
             this.dispatchEvent(
               new DemandEvent(
-                DemandEventType,
+                DEMAND_EVENT_TYPE,
                 undefined,
                 new GolemError(
                   `${error.code === "ECONNREFUSED" ? "Yagna connection error." : "Demand expired."} ${reason}`,

--- a/src/market/index.ts
+++ b/src/market/index.ts
@@ -1,5 +1,5 @@
 export { MarketService, ProposalFilter, MarketOptions } from "./service";
-export { Demand, DemandEventType, DemandOptions, DemandEvent } from "./demand";
+export { Demand, DEMAND_EVENT_TYPE, DemandOptions, DemandEvent } from "./demand";
 export { Proposal, ProposalDetails } from "./proposal";
 export { MarketDecoration } from "./builder";
 export { DemandConfig } from "./config";

--- a/src/market/proposal.ts
+++ b/src/market/proposal.ts
@@ -10,6 +10,7 @@ export type PricingInfo = {
   start: number;
 };
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type ProposalProperties = Record<string, string | number | string[] | number[] | boolean> & {
   "golem.activity.caps.transfer.protocol": string[];
   "golem.com.payment.debit-notes.accept-timeout?": number;

--- a/src/market/service.ts
+++ b/src/market/service.ts
@@ -3,7 +3,7 @@ import { Package } from "../package";
 import { Proposal } from "./proposal";
 import { AgreementPoolService } from "../agreement";
 import { Allocation } from "../payment";
-import { Demand, DemandEvent, DemandEventType, DemandOptions } from "./demand";
+import { Demand, DemandEvent, DEMAND_EVENT_TYPE, DemandOptions } from "./demand";
 import { MarketConfig } from "./config";
 import { GolemError } from "../error/golem-error";
 
@@ -50,7 +50,7 @@ export class MarketService {
 
   async end() {
     if (this.demand) {
-      this.demand.removeEventListener(DemandEventType, this.demandEventListener.bind(this));
+      this.demand.removeEventListener(DEMAND_EVENT_TYPE, this.demandEventListener.bind(this));
       await this.demand.unsubscribe().catch((e) => this.logger?.error(`Could not unsubscribe demand. ${e}`));
     }
     this.logger?.debug("Market Service has been stopped");
@@ -63,7 +63,7 @@ export class MarketService {
   private async createDemand(): Promise<true> {
     if (!this.taskPackage || !this.allocation) throw new GolemError("The service has not been started correctly.");
     this.demand = await Demand.create(this.taskPackage, this.allocation, this.yagnaApi, this.options);
-    this.demand.addEventListener(DemandEventType, this.demandEventListener.bind(this));
+    this.demand.addEventListener(DEMAND_EVENT_TYPE, this.demandEventListener.bind(this));
     this.proposalsCount = {
       initial: 0,
       confirmed: 0,
@@ -92,7 +92,7 @@ export class MarketService {
 
   private async resubscribeDemand() {
     if (this.demand) {
-      this.demand.removeEventListener(DemandEventType, this.demandEventListener.bind(this));
+      this.demand.removeEventListener(DEMAND_EVENT_TYPE, this.demandEventListener.bind(this));
       await this.demand.unsubscribe().catch((e) => this.logger?.debug(`Could not unsubscribe demand. ${e}`));
     }
     let attempt = 1;

--- a/src/package/config.ts
+++ b/src/package/config.ts
@@ -19,8 +19,8 @@ export const DEFAULTS = Object.freeze({
  * @internal
  */
 export enum PackageFormat {
-  UNKNOWN = "",
-  GVMKIT_SQUASH = "gvmkit-squash",
+  Unknown = "",
+  GVMKitSquash = "gvmkit-squash",
 }
 
 /**
@@ -49,7 +49,7 @@ export class PackageConfig {
       throw new GolemError("You must define a package or manifest option");
     }
 
-    this.packageFormat = PackageFormat.GVMKIT_SQUASH;
+    this.packageFormat = PackageFormat.GVMKitSquash;
     this.imageHash = options.imageHash;
     this.imageTag = options.imageTag;
     this.engine = options.engine || DEFAULTS.engine;

--- a/src/package/package.ts
+++ b/src/package/package.ts
@@ -74,10 +74,6 @@ export class Package {
     };
   }
 
-  static GetHashFromTag(tag: string): string {
-    return tag.split(":")[1];
-  }
-
   async getDemandDecoration(): Promise<MarketDecoration> {
     const builder = new DecorationsBuilder();
     builder

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -2,6 +2,6 @@ export { PaymentService, PaymentOptions } from "./service";
 export { Invoice } from "./invoice";
 export { DebitNote } from "./debit_note";
 export { Allocation } from "./allocation";
-export { Payments, PaymentEventType, InvoiceEvent, DebitNoteEvent } from "./payments";
+export { Payments, PAYMENT_EVENT_TYPE, InvoiceEvent, DebitNoteEvent } from "./payments";
 export { Rejection, RejectionReason } from "./rejection";
 export * as PaymentFilters from "./strategy";

--- a/src/payment/payments.ts
+++ b/src/payment/payments.ts
@@ -11,7 +11,7 @@ export interface PaymentOptions extends BasePaymentOptions {
   maxDebitNotesEvents?: number;
 }
 
-export const PaymentEventType = "PaymentReceived";
+export const PAYMENT_EVENT_TYPE = "PaymentReceived";
 
 export class Payments extends EventTarget {
   private isRunning = true;
@@ -70,7 +70,7 @@ export class Payments extends EventTarget {
               ),
           );
           if (!invoice) continue;
-          this.dispatchEvent(new InvoiceEvent(PaymentEventType, invoice));
+          this.dispatchEvent(new InvoiceEvent(PAYMENT_EVENT_TYPE, invoice));
           this.lastInvoiceFetchingTime = event.eventDate;
           this.options.eventTarget?.dispatchEvent(new Events.InvoiceReceived(invoice));
           this.logger?.debug(`New Invoice received for agreement ${invoice.agreementId}. Amount: ${invoice.amount}`);
@@ -105,7 +105,7 @@ export class Payments extends EventTarget {
               ),
           );
           if (!debitNote) continue;
-          this.dispatchEvent(new DebitNoteEvent(PaymentEventType, debitNote));
+          this.dispatchEvent(new DebitNoteEvent(PAYMENT_EVENT_TYPE, debitNote));
           this.lastDebitNotesFetchingTime = event.eventDate;
           this.options.eventTarget?.dispatchEvent(
             new Events.DebitNoteReceived({

--- a/src/payment/service.ts
+++ b/src/payment/service.ts
@@ -3,7 +3,7 @@ import { Allocation, AllocationOptions } from "./allocation";
 import { BasePaymentOptions, PaymentConfig } from "./config";
 import { Invoice, InvoiceDTO } from "./invoice";
 import { DebitNote, DebitNoteDTO } from "./debit_note";
-import { Payments, PaymentEventType, DebitNoteEvent, InvoiceEvent } from "./payments";
+import { Payments, PAYMENT_EVENT_TYPE, DebitNoteEvent, InvoiceEvent } from "./payments";
 import { RejectionReason } from "./rejection";
 import { GolemError } from "../error/golem-error";
 
@@ -55,7 +55,7 @@ export class PaymentService {
   async run() {
     this.isRunning = true;
     this.payments = await Payments.create(this.yagnaApi, this.config.options);
-    this.payments.addEventListener(PaymentEventType, this.subscribePayments.bind(this));
+    this.payments.addEventListener(PAYMENT_EVENT_TYPE, this.subscribePayments.bind(this));
     this.logger?.debug("Payment Service has started");
   }
 
@@ -78,7 +78,7 @@ export class PaymentService {
     }
     this.isRunning = false;
     await this.payments?.unsubscribe().catch((error) => this.logger?.warn(error));
-    this.payments?.removeEventListener(PaymentEventType, this.subscribePayments.bind(this));
+    this.payments?.removeEventListener(PAYMENT_EVENT_TYPE, this.subscribePayments.bind(this));
     await this.allocation?.release().catch((error) => this.logger?.warn(error));
     this.logger?.info("Allocation has been released");
     this.logger?.debug("Payment service has been stopped");

--- a/src/script/command.ts
+++ b/src/script/command.ts
@@ -2,7 +2,7 @@ import { ExeScriptRequest } from "ya-ts-client/dist/ya-activity/src/models";
 import { StorageProvider } from "../storage";
 import { Result, ResultState } from "../activity";
 
-const EmptyErrorResult = new Result({
+const EMPTY_ERROR_RESULT = new Result({
   result: ResultState.Error,
   eventDate: new Date().toISOString(),
   index: -1,
@@ -51,7 +51,7 @@ export class Command<T = unknown> {
    * @param result
    */
   async after(result?: Result<T>): Promise<Result<T>> {
-    return result ?? EmptyErrorResult;
+    return result ?? EMPTY_ERROR_RESULT;
   }
 }
 

--- a/src/stats/service.ts
+++ b/src/stats/service.ts
@@ -1,4 +1,4 @@
-import { Events, EventType, BaseEvent } from "../events";
+import { Events, EVENT_TYPE, BaseEvent } from "../events";
 import { Logger } from "../utils";
 import { Providers } from "./providers";
 import { Tasks } from "./tasks";
@@ -46,12 +46,12 @@ export class StatsService {
   }
 
   async run() {
-    this.eventTarget.addEventListener(EventType, (event) => this.handleEvents(event as BaseEvent<unknown>));
+    this.eventTarget.addEventListener(EVENT_TYPE, (event) => this.handleEvents(event as BaseEvent<unknown>));
     this.logger?.debug("Stats service has started");
   }
 
   async end() {
-    this.eventTarget.removeEventListener(EventType, null);
+    this.eventTarget.removeEventListener(EVENT_TYPE, null);
     this.logger?.debug("Stats service has stopped");
   }
 

--- a/src/storage/gftp.ts
+++ b/src/storage/gftp.ts
@@ -68,9 +68,9 @@ export class GftpStorageProvider implements StorageProvider {
   private async generateTempFileName(): Promise<string> {
     const { randomUUID } = await import("crypto");
     const tmp = await import("tmp");
-    const file_name = path.join(tmp.dirSync().name, randomUUID().toString());
-    if (fs.existsSync(file_name)) fs.unlinkSync(file_name);
-    return file_name;
+    const fileName = path.join(tmp.dirSync().name, randomUUID().toString());
+    if (fs.existsSync(fileName)) fs.unlinkSync(fileName);
+    return fileName;
   }
 
   async receiveFile(path: string): Promise<string> {
@@ -143,8 +143,8 @@ export class GftpStorageProvider implements StorageProvider {
 
   private async uploadStream(stream: AsyncGenerator<Buffer>): Promise<string> {
     // FIXME: temp file is never deleted.
-    const file_name = await this.generateTempFileName();
-    const wStream = fs.createWriteStream(file_name, {
+    const fileName = await this.generateTempFileName();
+    const wStream = fs.createWriteStream(fileName, {
       encoding: "binary",
     });
     // eslint-disable-next-line no-async-promise-executor
@@ -155,7 +155,7 @@ export class GftpStorageProvider implements StorageProvider {
       }
       wStream.end();
     });
-    const links = await this.jsonrpc("publish", { files: [file_name.toString()] });
+    const links = await this.jsonrpc("publish", { files: [fileName.toString()] });
     if (links.length !== 1) throw "invalid gftp publish response";
     return links[0]?.url;
   }

--- a/src/storage/ws-browser.ts
+++ b/src/storage/ws-browser.ts
@@ -169,8 +169,8 @@ export class WebSocketBrowserStorageProvider implements StorageProvider {
   private async createService(fileInfo: GftpFileInfo, components: string[]): Promise<ServiceInfo> {
     const resp = await this.yagnaApi.gsb.createService(fileInfo, components);
     const servicesId = resp.servicesId;
-    const messages_link = `/gsb-api/v1/services/${servicesId}?authToken=${this.yagnaApi.yagnaOptions.apiKey}`;
-    const url = new URL(messages_link, this.yagnaApi.yagnaOptions.basePath);
+    const messageEndpoint = `/gsb-api/v1/services/${servicesId}?authToken=${this.yagnaApi.yagnaOptions.apiKey}`;
+    const url = new URL(messageEndpoint, this.yagnaApi.yagnaOptions.basePath);
     url.protocol = "ws:";
     this.services.set(fileInfo.url, servicesId);
 

--- a/src/task/queue.ts
+++ b/src/task/queue.ts
@@ -15,12 +15,12 @@ export class TaskQueue<T extends QueueableTask = Task> {
   protected itemsStack: Array<T> = [];
 
   addToEnd(task: T) {
-    this._checkIfTaskIsEligibleForAdd(task);
+    this.checkIfTaskIsEligibleForAdd(task);
     this.itemsStack.push(task);
   }
 
   addToBegin(task: T) {
-    this._checkIfTaskIsEligibleForAdd(task);
+    this.checkIfTaskIsEligibleForAdd(task);
     this.itemsStack.unshift(task);
   }
 
@@ -32,7 +32,7 @@ export class TaskQueue<T extends QueueableTask = Task> {
     return this.itemsStack.shift();
   }
 
-  private _checkIfTaskIsEligibleForAdd(task: T) {
+  private checkIfTaskIsEligibleForAdd(task: T) {
     if (!task.isQueueable()) throw new GolemError("You cannot add a task that is not in the correct state");
   }
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,29 +1,27 @@
 import { isNode } from "./runtimeContextChecker";
 
-export const EnvUtils = {
-  getYagnaApiUrl(): string {
-    return (isNode ? process?.env.YAGNA_API_URL : "") || "http://127.0.0.1:7465";
-  },
+export function getYagnaApiUrl(): string {
+  return (isNode ? process?.env.YAGNA_API_URL : "") || "http://127.0.0.1:7465";
+}
 
-  getYagnaAppKey(): string {
-    return isNode ? process?.env.YAGNA_APPKEY ?? "" : "";
-  },
+export function getYagnaAppKey(): string {
+  return isNode ? process?.env.YAGNA_APPKEY ?? "" : "";
+}
 
-  getYagnaSubnet(): string {
-    return isNode ? process?.env.YAGNA_SUBNET ?? "public" : "public";
-  },
+export function getYagnaSubnet(): string {
+  return isNode ? process?.env.YAGNA_SUBNET ?? "public" : "public";
+}
 
-  getRepoUrl(): string {
-    return isNode
-      ? process?.env.GOLEM_REGISTRY_URL ?? "https://registry.golem.network"
-      : "https://registry.golem.network";
-  },
+export function getRepoUrl(): string {
+  return isNode
+    ? process?.env.GOLEM_REGISTRY_URL ?? "https://registry.golem.network"
+    : "https://registry.golem.network";
+}
 
-  getPaymentNetwork(): string {
-    return isNode ? process.env.PAYMENT_NETWORK ?? "goerli" : "goerli";
-  },
+export function getPaymentNetwork(): string {
+  return isNode ? process.env.PAYMENT_NETWORK ?? "goerli" : "goerli";
+}
 
-  isDevMode(): boolean {
-    return isNode ? process?.env.GOLEM_DEV_MODE === "true" : false;
-  },
-};
+export function isDevMode(): boolean {
+  return isNode ? process?.env.GOLEM_DEV_MODE === "true" : false;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,5 +7,5 @@ export { consoleLogger } from "./logger/consoleLogger";
 export { jsonLogger } from "./logger/jsonLogger";
 export { nullLogger } from "./logger/nullLogger";
 export { defaultLogger } from "./logger/defaultLogger";
-export { EnvUtils } from "./env";
+export * as EnvUtils from "./env";
 export { Yagna, YagnaApi } from "./yagna/yagna";

--- a/src/utils/yagna/yagna.ts
+++ b/src/utils/yagna/yagna.ts
@@ -6,7 +6,7 @@ import { RequestorApi as IdentityRequestorApi } from "./identity";
 import { RequestorApi as GsbRequestorApi } from "./gsb";
 import { Agent } from "http";
 import { Configuration } from "ya-ts-client/dist/ya-payment";
-import { EnvUtils } from "../env";
+import * as EnvUtils from "../env";
 import { GolemError } from "../../error/golem-error";
 
 export type YagnaApi = {

--- a/tests/unit/demand.test.ts
+++ b/tests/unit/demand.test.ts
@@ -1,5 +1,5 @@
 import { setExpectedProposals } from "../mock/rest/market";
-import { Demand, Proposal, DemandEventType, DemandEvent } from "../../src/market";
+import { Demand, Proposal, DEMAND_EVENT_TYPE, DemandEvent } from "../../src/market";
 import { allocationMock, packageMock, LoggerMock } from "../mock";
 import { proposalsInitial } from "../mock/fixtures";
 import { YagnaMock } from "../mock/rest/yagna";
@@ -22,7 +22,7 @@ describe("Demand", () => {
       const demand = await Demand.create(packageMock, allocationMock, yagnaApi, { subnetTag });
       setExpectedProposals(proposalsInitial);
       const event: DemandEvent = await new Promise((res) =>
-        demand.addEventListener(DemandEventType, (e) => res(e as DemandEvent)),
+        demand.addEventListener(DEMAND_EVENT_TYPE, (e) => res(e as DemandEvent)),
       );
       expect(event.proposal).toBeInstanceOf(Proposal);
       await demand.unsubscribe();


### PR DESCRIPTION
This PR implements the agreed coding conventions:

- private members cannot be prefixed with `_`
- we don't use poperty getters/setters - switched to `setX, getX` accessors
- the primary naming style is `camelCase` with `UPPER_CASE` and `PascalCase` in other cases