### PR TITLE
Wallet address field in payment events

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -3,6 +3,7 @@ import { PackageDetails } from "../package/package";
 import { DemandDetails } from "../market/demand";
 
 import { RequireAtLeastOne } from "../utils/types";
+import { ProviderInfo } from "../agreement";
 /**
  * Global Event Type with which all API events will be emitted. It should be used on all listeners that would like to handle events.
  */
@@ -45,8 +46,7 @@ export class TaskStarted extends BaseEvent<{
   id: string;
   agreementId: string;
   activityId: string;
-  providerId: string;
-  providerName: string;
+  provider: ProviderInfo;
 }> {}
 
 /**
@@ -55,8 +55,7 @@ export class TaskStarted extends BaseEvent<{
 export class TaskRedone extends BaseEvent<{
   id: string;
   agreementId: string;
-  providerId: string;
-  providerName: string;
+  provider: ProviderInfo;
   retriesCount: number;
   /**
    * The activity that was involved
@@ -74,8 +73,8 @@ export class TaskRedone extends BaseEvent<{
 export class TaskRejected extends BaseEvent<{
   id: string;
   agreementId: string;
-  providerId: string;
-  providerName: string;
+
+  provider: ProviderInfo;
   /**
    * The activity that was involved when the rejection took place
    *
@@ -92,28 +91,28 @@ export class DemandUnsubscribed extends BaseEvent<{ id: string }> {}
 export class CollectFailed extends BaseEvent<{ id: string; reason?: string }> {}
 export class ProposalReceived extends BaseEvent<{
   id: string;
-  providerId: string;
+  provider: ProviderInfo;
   parentId: string | null;
   details: ProposalDetails;
 }> {}
 export class ProposalRejected extends BaseEvent<{
   id: string;
-  providerId?: string;
+  provider: ProviderInfo;
   reason?: string;
   parentId: string | null;
 }> {}
 export class ProposalResponded extends BaseEvent<{
   id: string;
-  providerId: string;
+  provider: ProviderInfo;
   counteringProposalId: string;
 }> {}
 export class ProposalFailed extends BaseEvent<{
   id: string;
-  providerId: string;
+  provider: ProviderInfo;
   parentId: string | null;
   reason?: string;
 }> {}
-export class ProposalConfirmed extends BaseEvent<{ id: string; providerId: string }> {}
+export class ProposalConfirmed extends BaseEvent<{ id: string; provider: ProviderInfo }> {}
 export class PackageCreated extends BaseEvent<{
   packageReference: RequireAtLeastOne<{
     imageHash: string;
@@ -124,41 +123,37 @@ export class PackageCreated extends BaseEvent<{
 }> {}
 export class AgreementCreated extends BaseEvent<{
   id: string;
-  providerId: string;
-  providerName: string;
+  provider: ProviderInfo;
   proposalId: string;
   validTo?: string;
 }> {}
-export class AgreementConfirmed extends BaseEvent<{ id: string; providerId: string }> {}
-export class AgreementRejected extends BaseEvent<{ id: string; providerId: string; reason?: string }> {}
-export class AgreementTerminated extends BaseEvent<{ id: string; providerId: string; reason?: string }> {}
+export class AgreementConfirmed extends BaseEvent<{ id: string; provider: ProviderInfo }> {}
+export class AgreementRejected extends BaseEvent<{ id: string; provider: ProviderInfo; reason?: string }> {}
+export class AgreementTerminated extends BaseEvent<{ id: string; provider: ProviderInfo; reason?: string }> {}
 export class InvoiceReceived extends BaseEvent<{
   id: string;
-  providerId: string;
+  provider: ProviderInfo;
   agreementId: string;
   amount: number;
-  payeeAddr: string;
 }> {}
 export class DebitNoteReceived extends BaseEvent<{
   id: string;
   agreementId: string;
   activityId: string;
   amount: number;
-  payeeAddr: string;
+  provider: ProviderInfo;
 }> {}
 export class PaymentAccepted extends BaseEvent<{
   id: string;
-  providerId: string;
   agreementId: string;
   amount: number;
-  payeeAddr: string;
+  provider: ProviderInfo;
 }> {}
 export class DebitNoteAccepted extends BaseEvent<{
   id: string;
-  providerId: string;
   agreementId: string;
   amount: number;
-  payeeAddr: string;
+  provider: ProviderInfo;
 }> {}
 export class PaymentFailed extends BaseEvent<{ id: string; agreementId: string; reason?: string }> {}
 export class ActivityCreated extends BaseEvent<{ id: string; agreementId: string }> {}

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,4 +1,4 @@
-import { ProposalDetails } from "../market/proposal";
+import { ProposalDetails } from "../market";
 import { PackageDetails } from "../package/package";
 import { DemandDetails } from "../market/demand";
 
@@ -136,25 +136,29 @@ export class InvoiceReceived extends BaseEvent<{
   id: string;
   providerId: string;
   agreementId: string;
-  amount: string; // It is coming as a string
+  amount: number;
+  payeeAddr: string;
 }> {}
 export class DebitNoteReceived extends BaseEvent<{
   id: string;
   agreementId: string;
   activityId: string;
-  amount: string; // It is coming as a string
+  amount: number;
+  payeeAddr: string;
 }> {}
 export class PaymentAccepted extends BaseEvent<{
   id: string;
   providerId: string;
   agreementId: string;
-  amount: string; // It is coming as a string
+  amount: number;
+  payeeAddr: string;
 }> {}
 export class DebitNoteAccepted extends BaseEvent<{
   id: string;
   providerId: string;
   agreementId: string;
-  amount: string; // It is coming as a string
+  amount: number;
+  payeeAddr: string;
 }> {}
 export class PaymentFailed extends BaseEvent<{ id: string; agreementId: string; reason?: string }> {}
 export class ActivityCreated extends BaseEvent<{ id: string; agreementId: string }> {}

--- a/src/market/demand.ts
+++ b/src/market/demand.ts
@@ -2,7 +2,7 @@ import { Package } from "../package";
 import { Allocation } from "../payment";
 import { YagnaOptions } from "../executor";
 import { DemandFactory } from "./factory";
-import { Proposal } from "./proposal";
+import { Proposal, ProposalProperties } from "./proposal";
 import { Logger, sleep, YagnaApi } from "../utils";
 import { DemandConfig } from "./config";
 import { Events } from "../events";
@@ -135,6 +135,7 @@ export class Demand extends EventTarget {
   /**
    * @param id - demand ID
    * @param demandRequest - {@link DemandOfferBase}
+   * @param allocation - {@link Allocation}
    * @param yagnaApi - {@link YagnaApi}
    * @param options - {@link DemandConfig}
    * @hidden
@@ -142,6 +143,7 @@ export class Demand extends EventTarget {
   constructor(
     public readonly id: string,
     private demandRequest: DemandOfferBase,
+    private allocation: Allocation,
     private yagnaApi: YagnaApi,
     private options: DemandConfig,
   ) {
@@ -188,11 +190,19 @@ export class Demand extends EventTarget {
         for (const event of events as Array<ProposalEvent & ProposalRejectedEvent>) {
           if (event.eventType === "ProposalRejectedEvent") {
             this.logger?.debug(`Proposal rejected. Reason: ${event.reason?.message}`);
+            const proposalProperties = event.proposal.properties as ProposalProperties;
             this.options.eventTarget?.dispatchEvent(
               new Events.ProposalRejected({
                 id: event.proposalId,
                 parentId: this.findParentProposal(event.proposalId),
                 reason: event.reason?.message,
+                provider: {
+                  id: event.proposal.issuerId,
+                  name: proposalProperties["golem.node.id.name"],
+                  walletAddress: proposalProperties[
+                    `golem.com.payment.platform.${this.allocation.paymentPlatform}.address`
+                  ] as string,
+                },
               }),
             );
             continue;
@@ -204,6 +214,7 @@ export class Demand extends EventTarget {
             this.yagnaApi.market,
             event.proposal,
             this.demandRequest,
+            this.allocation.paymentPlatform,
             this.options.eventTarget,
           );
           this.dispatchEvent(new DemandEvent(DEMAND_EVENT_TYPE, proposal));
@@ -211,7 +222,7 @@ export class Demand extends EventTarget {
             new Events.ProposalReceived({
               id: proposal.id,
               parentId: this.findParentProposal(event.proposal.prevProposalId),
-              providerId: proposal.issuerId,
+              provider: proposal.provider,
               details: proposal.details,
             }),
           );

--- a/src/market/factory.ts
+++ b/src/market/factory.ts
@@ -37,7 +37,7 @@ export class DemandFactory {
       }),
     );
     this.options.logger?.info(`Demand published on the market`);
-    return new Demand(id, demandRequest, this.yagnaApi, this.options);
+    return new Demand(id, demandRequest, this.allocation, this.yagnaApi, this.options);
   }
 
   private async getDecorations(): Promise<MarketDecoration[]> {

--- a/src/market/proposal.test.ts
+++ b/src/market/proposal.test.ts
@@ -30,6 +30,7 @@ const buildTestProposal = (props: Partial<ProposalProperties>): Proposal => {
     mockApi,
     model,
     mockDemand,
+    "testPaymentPlatform",
   );
 
   return proposal;

--- a/src/payment/agreement_payment_process.test.ts
+++ b/src/payment/agreement_payment_process.test.ts
@@ -24,7 +24,7 @@ describe("AgreementPaymentProcess", () => {
     describe("Basic use cases", () => {
       it("accepts a invoice in RECEIVED state", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(invoiceMock.amount).thenReturn("0.123");
+        when(invoiceMock.amount).thenReturn(0.123);
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -35,7 +35,7 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addInvoice(instance(invoiceMock));
 
         expect(success).toEqual(true);
-        verify(invoiceMock.accept("0.123", "1000")).called();
+        verify(invoiceMock.accept(0.123, "1000")).called();
         expect(process.isFinished()).toEqual(true);
       });
 
@@ -43,7 +43,7 @@ describe("AgreementPaymentProcess", () => {
         when(allocationMock.id).thenReturn("1000");
         when(invoiceMock.id).thenReturn("invoice-id");
         when(invoiceMock.agreementId).thenReturn("agreement-id");
-        when(invoiceMock.amount).thenReturn("0.123");
+        when(invoiceMock.amount).thenReturn(0.123);
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -70,7 +70,7 @@ describe("AgreementPaymentProcess", () => {
         when(allocationMock.id).thenReturn("1000");
         when(invoiceMock.id).thenReturn("invoice-id");
         when(invoiceMock.agreementId).thenReturn("agreement-id");
-        when(invoiceMock.amount).thenReturn("0.123");
+        when(invoiceMock.amount).thenReturn(0.123);
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Accepted);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -82,7 +82,7 @@ describe("AgreementPaymentProcess", () => {
           "The invoice invoice-id for agreement agreement-id has status ACCEPTED, but we can accept only the ones with status RECEIVED",
         );
 
-        verify(invoiceMock.accept("0.123", "1000")).never();
+        verify(invoiceMock.accept(0.123, "1000")).never();
         expect(process.isFinished()).toEqual(false);
       });
     });
@@ -91,7 +91,7 @@ describe("AgreementPaymentProcess", () => {
       it("accepts the duplicated invoice if accepting the previous one failed", async () => {
         when(allocationMock.id).thenReturn("1000");
 
-        when(invoiceMock.amount).thenReturn("0.123");
+        when(invoiceMock.amount).thenReturn(0.123);
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
         when(invoiceMock.isSameAs(anything())).thenReturn(true);
 
@@ -104,7 +104,7 @@ describe("AgreementPaymentProcess", () => {
 
         // Simulate issue with accepting the first one
         const issue = new Error("Failed to accept in yagna");
-        when(invoiceMock.accept("0.123", "1000"))
+        when(invoiceMock.accept(0.123, "1000"))
           .thenReject(issue) // On first call
           .thenResolve(); // On second call
 
@@ -114,14 +114,14 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addInvoice(invoice);
 
         expect(success).toEqual(true);
-        verify(invoiceMock.accept("0.123", "1000")).twice();
+        verify(invoiceMock.accept(0.123, "1000")).twice();
         expect(process.isFinished()).toEqual(true);
       });
 
       it("accepts the duplicate if the original invoice has not been already decided upon (still in RECEIVED state)", async () => {
         when(allocationMock.id).thenReturn("1000");
 
-        when(invoiceMock.amount).thenReturn("0.123");
+        when(invoiceMock.amount).thenReturn(0.123);
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
         when(invoiceMock.isSameAs(anything())).thenReturn(true);
 
@@ -132,14 +132,14 @@ describe("AgreementPaymentProcess", () => {
 
         const invoice = instance(invoiceMock);
 
-        when(invoiceMock.accept("0.123", "1000")).thenResolve();
+        when(invoiceMock.accept(0.123, "1000")).thenResolve();
 
         const firstSuccess = await process.addInvoice(invoice);
         const secondSuccess = await process.addInvoice(invoice);
 
         expect(firstSuccess).toEqual(true);
         expect(secondSuccess).toEqual(true);
-        verify(invoiceMock.accept("0.123", "1000")).twice();
+        verify(invoiceMock.accept(0.123, "1000")).twice();
         expect(process.isFinished()).toEqual(true);
       });
 
@@ -193,7 +193,7 @@ describe("AgreementPaymentProcess", () => {
     describe("Basic use cases", () => {
       it("accepts a single debit note", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(debitNoteMock.totalAmountDue).thenReturn("0.123");
+        when(debitNoteMock.totalAmountDue).thenReturn(0.123);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
           debitNoteFilter: () => true,
@@ -205,13 +205,13 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addDebitNote(debitNote);
 
         expect(success).toEqual(true);
-        verify(debitNoteMock.accept("0.123", "1000")).called();
+        verify(debitNoteMock.accept(0.123, "1000")).called();
         expect(process.isFinished()).toEqual(false);
       });
 
       it("rejects debit note if it's ignored by the user defined debit note filter", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(debitNoteMock.totalAmountDue).thenReturn("0.123");
+        when(debitNoteMock.totalAmountDue).thenReturn(0.123);
         when(debitNoteMock.id).thenReturn("debit-note-id");
         when(debitNoteMock.agreementId).thenReturn("agreement-id");
 
@@ -239,9 +239,9 @@ describe("AgreementPaymentProcess", () => {
 
       it("rejects debit note if there is already an invoice for that process", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(invoiceMock.amount).thenReturn("0.123");
+        when(invoiceMock.amount).thenReturn(0.123);
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
-        when(debitNoteMock.totalAmountDue).thenReturn("0.456");
+        when(debitNoteMock.totalAmountDue).thenReturn(0.456);
         when(debitNoteMock.id).thenReturn("debit-note-id");
         when(debitNoteMock.agreementId).thenReturn("agreement-id");
 
@@ -257,7 +257,7 @@ describe("AgreementPaymentProcess", () => {
         const debitNoteSuccess = await process.addDebitNote(debitNote);
 
         expect(invoiceSuccess).toEqual(true);
-        verify(invoiceMock.accept("0.123", "1000")).called();
+        verify(invoiceMock.accept(0.123, "1000")).called();
 
         expect(debitNoteSuccess).toEqual(false);
         verify(
@@ -277,7 +277,7 @@ describe("AgreementPaymentProcess", () => {
     describe("Dealing with duplicates", () => {
       it("accepts the duplicated debit note if accepting the previous failed", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(debitNoteMock.totalAmountDue).thenReturn("0.123");
+        when(debitNoteMock.totalAmountDue).thenReturn(0.123);
         when(debitNoteMock.getStatus()).thenResolve(InvoiceStatus.Received);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -289,7 +289,7 @@ describe("AgreementPaymentProcess", () => {
 
         // Simulate issue with accepting the first one
         const issue = new Error("Failed to accept in yagna");
-        when(debitNoteMock.accept("0.123", "1000"))
+        when(debitNoteMock.accept(0.123, "1000"))
           .thenReject(issue) // On first call
           .thenResolve(); // On second call
 
@@ -299,7 +299,7 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addDebitNote(debitNote);
 
         expect(success).toEqual(true);
-        verify(debitNoteMock.accept("0.123", "1000")).twice();
+        verify(debitNoteMock.accept(0.123, "1000")).twice();
         expect(process.isFinished()).toEqual(false);
       });
 

--- a/src/payment/invoice.ts
+++ b/src/payment/invoice.ts
@@ -4,19 +4,20 @@ import { Events } from "../events";
 import { Rejection } from "./rejection";
 import { YagnaApi } from "../utils";
 import { GolemError } from "../error/golem-error";
+import { ProviderInfo } from "../agreement";
+import { ProposalProperties } from "../market/proposal";
 
 export type InvoiceOptions = BasePaymentOptions;
 
 export interface InvoiceDTO {
   id: string;
-  providerId: string;
   timestamp: string;
   activityIds?: string[];
   agreementId: string;
   paymentDueDate?: string;
   status: string;
-  payeeAddr: string;
-  payerAddr: string;
+  requestorWalletAddress: string;
+  provider: ProviderInfo;
   paymentPlatform: string;
   amount: number;
 }
@@ -40,10 +41,9 @@ export interface BaseModel {
  */
 export abstract class BaseNote<ModelType extends BaseModel> {
   public abstract readonly id: string;
-  public readonly providerId: string;
   public readonly recipientId: string;
   public readonly payeeAddr: string;
-  public readonly payerAddr: string;
+  public readonly requestorWalletAddress: string;
   public readonly paymentPlatform: string;
   public readonly agreementId: string;
   public readonly paymentDueDate?: string;
@@ -51,12 +51,12 @@ export abstract class BaseNote<ModelType extends BaseModel> {
 
   protected constructor(
     protected model: ModelType,
+    public readonly provider: ProviderInfo,
     protected options: InvoiceConfig,
   ) {
-    this.providerId = model.issuerId;
     this.recipientId = model.recipientId;
     this.payeeAddr = model.payeeAddr;
-    this.payerAddr = model.payerAddr;
+    this.requestorWalletAddress = model.payerAddr;
     this.paymentPlatform = model.paymentPlatform;
     this.agreementId = model.agreementId;
     this.paymentDueDate = model.paymentDueDate;
@@ -97,11 +97,18 @@ export class Invoice extends BaseNote<Model> {
   static async create(invoiceId: string, yagnaApi: YagnaApi, options?: InvoiceOptions): Promise<Invoice> {
     const config = new InvoiceConfig(options);
     const { data: model } = await yagnaApi.payment.getInvoice(invoiceId);
-    return new Invoice(model, yagnaApi, config);
+    const { data: agreement } = await yagnaApi.market.getAgreement(model.agreementId);
+    const providerInfo = {
+      id: model.issuerId,
+      walletAddress: model.payeeAddr,
+      name: (agreement.offer.properties as ProposalProperties)["golem.node.id.name"],
+    };
+    return new Invoice(model, providerInfo, yagnaApi, config);
   }
 
   /**
    * @param model
+   * @param providerInfo
    * @param yagnaApi
    * @param options
    * @protected
@@ -109,10 +116,11 @@ export class Invoice extends BaseNote<Model> {
    */
   protected constructor(
     protected model: Model,
+    providerInfo: ProviderInfo,
     protected yagnaApi: YagnaApi,
     protected options: InvoiceConfig,
   ) {
-    super(model, options);
+    super(model, providerInfo, options);
     this.id = model.invoiceId;
     this.activityIds = model.activityIds;
     this.amount = Number(model.amount);
@@ -123,14 +131,13 @@ export class Invoice extends BaseNote<Model> {
   get dto(): InvoiceDTO {
     return {
       id: this.id,
-      providerId: this.providerId,
       timestamp: this.timestamp,
       activityIds: this.activityIds,
       agreementId: this.agreementId,
       paymentDueDate: this.paymentDueDate,
       status: this.status,
-      payeeAddr: this.payeeAddr,
-      payerAddr: this.payerAddr,
+      requestorWalletAddress: this.requestorWalletAddress,
+      provider: this.provider,
       paymentPlatform: this.paymentPlatform,
       amount: this.amount,
     };
@@ -168,10 +175,9 @@ export class Invoice extends BaseNote<Model> {
     this.options.eventTarget?.dispatchEvent(
       new Events.PaymentAccepted({
         id: this.id,
-        providerId: this.providerId,
         agreementId: this.agreementId,
         amount: this.amount,
-        payeeAddr: this.payeeAddr,
+        provider: this.provider,
       }),
     );
   }

--- a/src/payment/payments.ts
+++ b/src/payment/payments.ts
@@ -75,10 +75,9 @@ export class Payments extends EventTarget {
           this.options.eventTarget?.dispatchEvent(
             new Events.InvoiceReceived({
               id: invoice.id,
-              providerId: invoice.providerId,
               agreementId: invoice.agreementId,
-              amount: Number(invoice.amount),
-              payeeAddr: invoice.payeeAddr,
+              amount: invoice.amount,
+              provider: invoice.provider,
             }),
           );
           this.logger?.debug(`New Invoice received for agreement ${invoice.agreementId}. Amount: ${invoice.amount}`);
@@ -122,8 +121,8 @@ export class Payments extends EventTarget {
               id: debitNote.id,
               agreementId: debitNote.agreementId,
               activityId: debitNote.activityId,
-              amount: Number(debitNote.totalAmountDue),
-              payeeAddr: debitNote.payeeAddr,
+              amount: debitNote.totalAmountDue,
+              provider: debitNote.provider,
             }),
           );
           this.logger?.debug(

--- a/src/payment/payments.ts
+++ b/src/payment/payments.ts
@@ -72,7 +72,15 @@ export class Payments extends EventTarget {
           if (!invoice) continue;
           this.dispatchEvent(new InvoiceEvent(PAYMENT_EVENT_TYPE, invoice));
           this.lastInvoiceFetchingTime = event.eventDate;
-          this.options.eventTarget?.dispatchEvent(new Events.InvoiceReceived(invoice));
+          this.options.eventTarget?.dispatchEvent(
+            new Events.InvoiceReceived({
+              id: invoice.id,
+              providerId: invoice.providerId,
+              agreementId: invoice.agreementId,
+              amount: Number(invoice.amount),
+              payeeAddr: invoice.payeeAddr,
+            }),
+          );
           this.logger?.debug(`New Invoice received for agreement ${invoice.agreementId}. Amount: ${invoice.amount}`);
         }
       } catch (error) {
@@ -114,7 +122,8 @@ export class Payments extends EventTarget {
               id: debitNote.id,
               agreementId: debitNote.agreementId,
               activityId: debitNote.activityId,
-              amount: debitNote.totalAmountDue,
+              amount: Number(debitNote.totalAmountDue),
+              payeeAddr: debitNote.payeeAddr,
             }),
           );
           this.logger?.debug(

--- a/src/payment/service.ts
+++ b/src/payment/service.ts
@@ -134,7 +134,7 @@ export class PaymentService {
         );
       }
     } catch (error) {
-      this.logger?.error(`Invoice failed from provider ${invoice.providerId}. ${error}`);
+      this.logger?.error(`Invoice failed from provider ${invoice.provider.id}. ${error}`);
     } finally {
       // Until we implement a re-acceptance mechanism for unsuccessful acceptances,
       // we no longer have to wait for the invoice during an unsuccessful attempt.

--- a/src/stats/agreements.ts
+++ b/src/stats/agreements.ts
@@ -1,4 +1,5 @@
 import { AbstractAggregator } from "./abstract_aggregator";
+import { ProviderInfo } from "../agreement";
 
 export enum AgreementStatusEnum {
   Pending = "pending",
@@ -8,15 +9,15 @@ export enum AgreementStatusEnum {
 
 export interface AgreementInfo {
   id: string;
-  providerId: string;
   proposalId: string;
+  provider: ProviderInfo;
   status: AgreementStatusEnum;
 }
 
 interface Payload {
   id: string;
-  providerId: string;
   proposalId: string;
+  provider: ProviderInfo;
 }
 
 export class Agreements extends AbstractAggregator<Payload, AgreementInfo> {
@@ -30,7 +31,7 @@ export class Agreements extends AbstractAggregator<Payload, AgreementInfo> {
     this.updateItemInfo(id, { status: AgreementStatusEnum.Rejected });
   }
   getByProviderId(providerId: string) {
-    return this.getByField("providerId", providerId);
+    return this.getByField("provider.id", providerId);
   }
   getByProposalId(proposalId: string) {
     return this.getByField("proposalId", proposalId).first();

--- a/src/stats/invoices.ts
+++ b/src/stats/invoices.ts
@@ -1,18 +1,17 @@
 import { AbstractAggregator } from "./abstract_aggregator";
+import { ProviderInfo } from "../agreement";
 
 export interface InvoiceInfo {
   id: string;
-  providerId: string;
   agreementId: string;
-  payeeAddr: string;
   amount: number;
+  provider: ProviderInfo;
 }
 interface Payload {
   id: string;
-  providerId: string;
   agreementId: string;
-  payeeAddr: string;
   amount: number;
+  provider: ProviderInfo;
 }
 
 export class Invoices extends AbstractAggregator<Payload, InvoiceInfo> {
@@ -20,7 +19,7 @@ export class Invoices extends AbstractAggregator<Payload, InvoiceInfo> {
     return payload;
   }
   getByProviderId(providerId: string) {
-    return this.getByField("providerId", providerId);
+    return this.getByField("provider.id", providerId);
   }
   getByAgreementId(agreementId: string) {
     return this.getByField("agreementId", agreementId);

--- a/src/stats/invoices.ts
+++ b/src/stats/invoices.ts
@@ -4,21 +4,20 @@ export interface InvoiceInfo {
   id: string;
   providerId: string;
   agreementId: string;
+  payeeAddr: string;
   amount: number;
 }
 interface Payload {
   id: string;
   providerId: string;
   agreementId: string;
-  amount: string;
+  payeeAddr: string;
+  amount: number;
 }
 
 export class Invoices extends AbstractAggregator<Payload, InvoiceInfo> {
   beforeAdd(payload: Payload): InvoiceInfo {
-    return {
-      ...payload,
-      amount: parseFloat(payload.amount),
-    };
+    return payload;
   }
   getByProviderId(providerId: string) {
     return this.getByField("providerId", providerId);

--- a/src/stats/payments.ts
+++ b/src/stats/payments.ts
@@ -1,18 +1,17 @@
 import { AbstractAggregator } from "./abstract_aggregator";
+import { ProviderInfo } from "../agreement";
 
 export interface PaymentInfo {
   id: string;
-  providerId: string;
   agreementId: string;
-  payeeAddr: string;
   amount: number;
+  provider: ProviderInfo;
 }
 interface Payload {
   id: string;
-  providerId: string;
   agreementId: string;
-  payeeAddr: string;
   amount: number;
+  provider: ProviderInfo;
 }
 
 export class Payments extends AbstractAggregator<Payload, PaymentInfo> {
@@ -20,7 +19,7 @@ export class Payments extends AbstractAggregator<Payload, PaymentInfo> {
     return payload;
   }
   getByProviderId(providerId: string) {
-    return this.getByField("providerId", providerId);
+    return this.getByField("provider.id", providerId);
   }
 
   getByAgreementId(agreementId: string) {

--- a/src/stats/payments.ts
+++ b/src/stats/payments.ts
@@ -4,21 +4,20 @@ export interface PaymentInfo {
   id: string;
   providerId: string;
   agreementId: string;
+  payeeAddr: string;
   amount: number;
 }
 interface Payload {
   id: string;
   providerId: string;
   agreementId: string;
-  amount: string;
+  payeeAddr: string;
+  amount: number;
 }
 
 export class Payments extends AbstractAggregator<Payload, PaymentInfo> {
   beforeAdd(payload: Payload): PaymentInfo {
-    return {
-      ...payload,
-      amount: parseFloat(payload.amount),
-    };
+    return payload;
   }
   getByProviderId(providerId: string) {
     return this.getByField("providerId", providerId);

--- a/src/stats/service.ts
+++ b/src/stats/service.ts
@@ -201,6 +201,7 @@ export class StatsService {
         id: event.detail.id,
         providerId: event.detail.providerId,
         agreementId: event.detail.agreementId,
+        payeeAddr: event.detail.payeeAddr,
         amount: event.detail.amount,
       });
     } else if (event instanceof Events.PaymentAccepted) {
@@ -208,6 +209,7 @@ export class StatsService {
         id: event.detail.id,
         providerId: event.detail.providerId,
         agreementId: event.detail.agreementId,
+        payeeAddr: event.detail.payeeAddr,
         amount: event.detail.amount,
       });
     }

--- a/src/stats/service.ts
+++ b/src/stats/service.ts
@@ -59,7 +59,7 @@ export class StatsService {
     return this.agreements
       .getAll()
       .map((agreement) => {
-        const provider = this.providers.getById(agreement.providerId);
+        const provider = this.providers.getById(agreement.provider.id);
         const tasks = this.tasks.getByAgreementId(agreement.id);
         const invoices = this.invoices.getByAgreementId(agreement.id);
         const payments = this.payments.getByAgreementId(agreement.id);
@@ -141,7 +141,7 @@ export class StatsService {
       agreements: this.agreements
         .getAll()
         .map((agreement) => {
-          const provider = this.providers.getById(agreement.providerId);
+          const provider = this.providers.getById(agreement.provider.id);
           const tasks = this.tasks.getByAgreementId(agreement.id);
           const invoices = this.invoices.getByAgreementId(agreement.id);
           const payments = this.payments.getByAgreementId(agreement.id);
@@ -185,32 +185,30 @@ export class StatsService {
     } else if (event instanceof Events.AgreementCreated) {
       this.agreements.add({
         id: event.detail.id,
-        providerId: event.detail.providerId,
+        provider: event.detail.provider,
         proposalId: event.detail.proposalId,
       });
-      this.providers.add({ id: event.detail.providerId, providerName: event.detail.providerName });
+      this.providers.add(event.detail.provider);
     } else if (event instanceof Events.AgreementConfirmed) {
       this.agreements.confirm(event.detail.id);
     } else if (event instanceof Events.AgreementRejected) {
       this.agreements.reject(event.detail.id);
     } else if (event instanceof Events.ProposalReceived) {
-      this.proposals.add({ id: event.detail.id, providerId: event.detail.providerId });
-      this.providers.add({ id: event.detail.providerId });
+      this.proposals.add({ id: event.detail.id, providerId: event.detail.provider.id });
+      this.providers.add({ id: event.detail.provider.id });
     } else if (event instanceof Events.InvoiceReceived) {
       this.invoices.add({
         id: event.detail.id,
-        providerId: event.detail.providerId,
+        provider: event.detail.provider,
         agreementId: event.detail.agreementId,
-        payeeAddr: event.detail.payeeAddr,
         amount: event.detail.amount,
       });
     } else if (event instanceof Events.PaymentAccepted) {
       this.payments.add({
         id: event.detail.id,
-        providerId: event.detail.providerId,
         agreementId: event.detail.agreementId,
-        payeeAddr: event.detail.payeeAddr,
         amount: event.detail.amount,
+        provider: event.detail.provider,
       });
     }
   }

--- a/src/task/service.ts
+++ b/src/task/service.ts
@@ -89,8 +89,7 @@ export class TaskService {
           id: task.id,
           agreementId: agreement.id,
           activityId: activity.id,
-          providerId: agreement.provider.id,
-          providerName: agreement.provider.name,
+          provider: agreement.provider,
         }),
       );
 
@@ -137,8 +136,7 @@ export class TaskService {
             id: task.id,
             activityId: activity?.id,
             agreementId: agreement.id,
-            providerId: agreement.provider.id,
-            providerName: agreement.provider.name,
+            provider: agreement.provider,
             retriesCount: task.getRetriesCount(),
             reason,
           }),
@@ -152,8 +150,7 @@ export class TaskService {
             id: task.id,
             agreementId: agreement.id,
             activityId: activity?.id,
-            providerId: agreement.provider.id,
-            providerName: agreement.provider.name,
+            provider: agreement.provider,
             reason,
           }),
         );

--- a/tests/mock/entities/agreement.ts
+++ b/tests/mock/entities/agreement.ts
@@ -5,7 +5,7 @@ import { AgreementStateEnum } from "ya-ts-client/dist/ya-market/src/models";
 // @ts-ignore
 export const agreement: Agreement = {
   id: "test_agreement_id",
-  provider: { id: "test_provider_id", name: "test_provider_name" },
+  provider: { id: "test_provider_id", name: "Test Provider", walletAddress: "test_wallet_address" },
   async confirm(): Promise<void> {
     return Promise.resolve(undefined);
   },

--- a/tests/mock/services/agrrement_pool.ts
+++ b/tests/mock/services/agrrement_pool.ts
@@ -7,7 +7,7 @@ import { YagnaMock } from "../rest/yagna";
 
 const proposals: Proposal[] = [];
 const invalidProviderIds: string[] = [];
-const provider = { id: "test_provider_id", name: "Test Provider" };
+const provider = { id: "test_provider_id", name: "Test Provider", walletAddress: "test_wallet_address" };
 const yagnaApi = new YagnaMock().getApi();
 // @ts-ignore
 export const agreementPoolServiceMock: AgreementPoolService = {

--- a/tests/unit/agreement_pool_service.test.ts
+++ b/tests/unit/agreement_pool_service.test.ts
@@ -36,10 +36,18 @@ const createProposal = (id) => {
     },
   };
 
-  return new Proposal(id, null, mockSetCounteringProposalReference, mockAPI, model, {
-    constraints: "",
-    properties: {},
-  });
+  return new Proposal(
+    id,
+    null,
+    mockSetCounteringProposalReference,
+    mockAPI,
+    model,
+    {
+      constraints: "",
+      properties: {},
+    },
+    "test-payment-platform",
+  );
 };
 
 describe("Agreement Pool Service", () => {

--- a/tests/unit/demand.test.ts
+++ b/tests/unit/demand.test.ts
@@ -1,8 +1,7 @@
 import { setExpectedProposals } from "../mock/rest/market";
 import { Demand, Proposal, DEMAND_EVENT_TYPE, DemandEvent } from "../../src/market";
-import { allocationMock, packageMock, LoggerMock } from "../mock";
+import { allocationMock, packageMock, LoggerMock, YagnaMock } from "../mock";
 import { proposalsInitial } from "../mock/fixtures";
-import { YagnaMock } from "../mock/rest/yagna";
 
 const subnetTag = "testnet";
 const logger = new LoggerMock();

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -131,7 +131,13 @@ describe("Stats Module", () => {
   describe("Invoices", () => {
     it("should beforeAdd() converts payload to InvoiceInfo", async () => {
       const tests = new Invoices();
-      tests.add({ id: "id", amount: "100", providerId: "providerId", agreementId: "agreementId" });
+      tests.add({
+        id: "id",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId",
+        payeeAddr: "test_address",
+      });
       expect(tests.getAll()).toEqual(
         new Collection([
           {
@@ -139,29 +145,72 @@ describe("Stats Module", () => {
             amount: 100,
             providerId: "providerId",
             agreementId: "agreementId",
+            payeeAddr: "test_address",
           },
         ]),
       );
     });
     it("should getByProviderId() return filtered Collection of InvoiceInfo", async () => {
       const tests = new Invoices();
-      tests.add({ id: "id", amount: "100", providerId: "providerId", agreementId: "agreementId" });
-      tests.add({ id: "id2", amount: "100", providerId: "providerId2", agreementId: "agreementId2" });
-      tests.add({ id: "id3", amount: "100", providerId: "providerId", agreementId: "agreementId3" });
+      tests.add({
+        id: "id",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId",
+        payeeAddr: "test_address",
+      });
+      tests.add({
+        id: "id2",
+        amount: 100,
+        providerId: "providerId2",
+        agreementId: "agreementId2",
+        payeeAddr: "test_address2",
+      });
+      tests.add({
+        id: "id3",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId3",
+        payeeAddr: "test_address3",
+      });
       expect(tests.getByProviderId("providerId").count()).toEqual(2);
     });
     it("should getByAgreementId() return filtered Collection of InvoiceInfo", async () => {
       const tests = new Invoices();
-      tests.add({ id: "id", amount: "100", providerId: "providerId", agreementId: "agreementId" });
-      tests.add({ id: "id2", amount: "100", providerId: "providerId2", agreementId: "agreementId2" });
-      tests.add({ id: "id3", amount: "100", providerId: "providerId3", agreementId: "agreementId" });
+      tests.add({
+        id: "id",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId",
+        payeeAddr: "test_address",
+      });
+      tests.add({
+        id: "id2",
+        amount: 100,
+        providerId: "providerId2",
+        agreementId: "agreementId2",
+        payeeAddr: "test_address2",
+      });
+      tests.add({
+        id: "id3",
+        amount: 100,
+        providerId: "providerId3",
+        agreementId: "agreementId",
+        payeeAddr: "test_address3",
+      });
       expect(tests.getByAgreementId("agreementId").count()).toEqual(2);
     });
   });
   describe("Payments", () => {
     it("should beforeAdd() converts payload to PaymentInfo", async () => {
       const tests = new Payments();
-      tests.add({ id: "id", amount: "100", providerId: "providerId", agreementId: "agreementId" });
+      tests.add({
+        id: "id",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId",
+        payeeAddr: "test_address",
+      });
       expect(tests.getAll()).toEqual(
         new Collection([
           {
@@ -169,22 +218,59 @@ describe("Stats Module", () => {
             amount: 100,
             providerId: "providerId",
             agreementId: "agreementId",
+            payeeAddr: "test_address",
           },
         ]),
       );
     });
     it("should getByProviderId() return filtered Collection of PaymentInfo", async () => {
       const tests = new Payments();
-      tests.add({ id: "id", amount: "100", providerId: "providerId", agreementId: "agreementId" });
-      tests.add({ id: "id2", amount: "100", providerId: "providerId2", agreementId: "agreementId2" });
-      tests.add({ id: "id3", amount: "100", providerId: "providerId", agreementId: "agreementId3" });
+      tests.add({
+        id: "id",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId",
+        payeeAddr: "test_address",
+      });
+      tests.add({
+        id: "id2",
+        amount: 100,
+        providerId: "providerId2",
+        agreementId: "agreementId2",
+        payeeAddr: "test_address2",
+      });
+      tests.add({
+        id: "id3",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId3",
+        payeeAddr: "test_address3",
+      });
       expect(tests.getByProviderId("providerId").count()).toEqual(2);
     });
     it("should getByAgreementId() return filtered Collection of PaymentInfo", async () => {
       const tests = new Payments();
-      tests.add({ id: "id", amount: "100", providerId: "providerId", agreementId: "agreementId" });
-      tests.add({ id: "id2", amount: "100", providerId: "providerId2", agreementId: "agreementId2" });
-      tests.add({ id: "id3", amount: "100", providerId: "providerId3", agreementId: "agreementId" });
+      tests.add({
+        id: "id",
+        amount: 100,
+        providerId: "providerId",
+        agreementId: "agreementId",
+        payeeAddr: "test_address",
+      });
+      tests.add({
+        id: "id2",
+        amount: 100,
+        providerId: "providerId2",
+        agreementId: "agreementId2",
+        payeeAddr: "test_address2",
+      });
+      tests.add({
+        id: "id3",
+        amount: 100,
+        providerId: "providerId3",
+        agreementId: "agreementId",
+        payeeAddr: "test_address3",
+      });
       expect(tests.getByAgreementId("agreementId").count()).toEqual(2);
     });
   });

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -9,6 +9,24 @@ import { Providers } from "../../src/stats/providers";
 import { Tasks, TaskStatusEnum } from "../../src/stats/tasks";
 import { Collection } from "collect.js";
 
+const testProvider = {
+  id: "testId",
+  name: "test name",
+  walletAddress: "testWalletAddress",
+};
+
+const testProvider2 = {
+  id: "testId2",
+  name: "test name2",
+  walletAddress: "testWalletAddress2",
+};
+
+const testProvider3 = {
+  id: "testId3",
+  name: "test name3",
+  walletAddress: "testWalletAddress3",
+};
+
 describe("Stats Module", () => {
   describe("Abstract Aggregator", () => {
     it("should add() add items", async () => {
@@ -70,22 +88,22 @@ describe("Stats Module", () => {
   describe("Agreements", () => {
     it("should beforeAdd() converts payload to AgreementInfo", async () => {
       const tests = new Agreements();
-      tests.add({ id: "id", providerId: "providerId", proposalId: "proposalId" });
+      tests.add({ id: "id", provider: testProvider, proposalId: "proposalId" });
       expect(tests.getAll()).toEqual(
         new Collection([
-          { id: "id", providerId: "providerId", proposalId: "proposalId", status: AgreementStatusEnum.Pending },
+          { id: "id", provider: testProvider, proposalId: "proposalId", status: AgreementStatusEnum.Pending },
         ]),
       );
     });
     it("should confirm() flag AgreementInfo.status as confirmed ", async () => {
       const tests = new Agreements();
-      tests.add({ id: "id", providerId: "providerId", proposalId: "proposalId" });
+      tests.add({ id: "id", provider: testProvider, proposalId: "proposalId" });
       tests.confirm("id");
       expect(tests.getAll()).toEqual(
         new Collection([
           {
             id: "id",
-            providerId: "providerId",
+            provider: testProvider,
             proposalId: "proposalId",
             status: AgreementStatusEnum.Confirmed,
           },
@@ -94,28 +112,28 @@ describe("Stats Module", () => {
     });
     it("should reject() flag AgreementInfo.status as rejected ", async () => {
       const tests = new Agreements();
-      tests.add({ id: "id", providerId: "providerId", proposalId: "proposalId" });
+      tests.add({ id: "id", provider: testProvider, proposalId: "proposalId" });
       tests.reject("id");
       expect(tests.getAll()).toEqual(
         new Collection([
-          { id: "id", providerId: "providerId", proposalId: "proposalId", status: AgreementStatusEnum.Rejected },
+          { id: "id", provider: testProvider, proposalId: "proposalId", status: AgreementStatusEnum.Rejected },
         ]),
       );
     });
     it("should getByProviderId() return filtered Collection of AgreementInfo", async () => {
       const tests = new Agreements();
-      tests.add({ id: "id", providerId: "providerId", proposalId: "proposalId" });
-      tests.add({ id: "id2", providerId: "providerId2", proposalId: "proposalId" });
-      tests.add({ id: "id3", providerId: "providerId", proposalId: "proposalId" });
-      expect(tests.getByProviderId("providerId").count()).toEqual(2);
+      tests.add({ id: "id", provider: testProvider, proposalId: "proposalId" });
+      tests.add({ id: "id2", provider: testProvider2, proposalId: "proposalId" });
+      tests.add({ id: "id3", provider: testProvider, proposalId: "proposalId" });
+      expect(tests.getByProviderId(testProvider.id).count()).toEqual(2);
     });
     it("should getByStatus() return filtered Collection of AgreementInfo", async () => {
       const tests = new Agreements();
-      tests.add({ id: "id", providerId: "providerId", proposalId: "proposalId" });
+      tests.add({ id: "id", provider: testProvider, proposalId: "proposalId" });
       tests.reject("id");
-      tests.add({ id: "id2", providerId: "providerId2", proposalId: "proposalId" });
+      tests.add({ id: "id2", provider: testProvider2, proposalId: "proposalId" });
       tests.confirm("id2");
-      tests.add({ id: "id3", providerId: "providerId", proposalId: "proposalId" });
+      tests.add({ id: "id3", provider: testProvider, proposalId: "proposalId" });
       expect(tests.getByStatus(AgreementStatusEnum.Rejected).count()).toEqual(1);
       expect(tests.getByStatus(AgreementStatusEnum.Confirmed).count()).toEqual(1);
       expect(tests.getByStatus(AgreementStatusEnum.Pending).count()).toEqual(1);
@@ -134,18 +152,16 @@ describe("Stats Module", () => {
       tests.add({
         id: "id",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
-        payeeAddr: "test_address",
       });
       expect(tests.getAll()).toEqual(
         new Collection([
           {
             id: "id",
             amount: 100,
-            providerId: "providerId",
+            provider: testProvider,
             agreementId: "agreementId",
-            payeeAddr: "test_address",
           },
         ]),
       );
@@ -155,48 +171,42 @@ describe("Stats Module", () => {
       tests.add({
         id: "id",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
-        payeeAddr: "test_address",
       });
       tests.add({
         id: "id2",
         amount: 100,
-        providerId: "providerId2",
+        provider: testProvider2,
         agreementId: "agreementId2",
-        payeeAddr: "test_address2",
       });
       tests.add({
         id: "id3",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId3",
-        payeeAddr: "test_address3",
       });
-      expect(tests.getByProviderId("providerId").count()).toEqual(2);
+      expect(tests.getByProviderId(testProvider.id).count()).toEqual(2);
     });
     it("should getByAgreementId() return filtered Collection of InvoiceInfo", async () => {
       const tests = new Invoices();
       tests.add({
         id: "id",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
-        payeeAddr: "test_address",
       });
       tests.add({
         id: "id2",
         amount: 100,
-        providerId: "providerId2",
+        provider: testProvider2,
         agreementId: "agreementId2",
-        payeeAddr: "test_address2",
       });
       tests.add({
         id: "id3",
         amount: 100,
-        providerId: "providerId3",
+        provider: testProvider3,
         agreementId: "agreementId",
-        payeeAddr: "test_address3",
       });
       expect(tests.getByAgreementId("agreementId").count()).toEqual(2);
     });
@@ -207,18 +217,16 @@ describe("Stats Module", () => {
       tests.add({
         id: "id",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
-        payeeAddr: "test_address",
       });
       expect(tests.getAll()).toEqual(
         new Collection([
           {
             id: "id",
             amount: 100,
-            providerId: "providerId",
+            provider: testProvider,
             agreementId: "agreementId",
-            payeeAddr: "test_address",
           },
         ]),
       );
@@ -228,48 +236,42 @@ describe("Stats Module", () => {
       tests.add({
         id: "id",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
-        payeeAddr: "test_address",
       });
       tests.add({
         id: "id2",
         amount: 100,
-        providerId: "providerId2",
+        provider: testProvider2,
         agreementId: "agreementId2",
-        payeeAddr: "test_address2",
       });
       tests.add({
         id: "id3",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId3",
-        payeeAddr: "test_address3",
       });
-      expect(tests.getByProviderId("providerId").count()).toEqual(2);
+      expect(tests.getByProviderId(testProvider.id).count()).toEqual(2);
     });
     it("should getByAgreementId() return filtered Collection of PaymentInfo", async () => {
       const tests = new Payments();
       tests.add({
         id: "id",
         amount: 100,
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
-        payeeAddr: "test_address",
       });
       tests.add({
         id: "id2",
         amount: 100,
-        providerId: "providerId2",
+        provider: testProvider2,
         agreementId: "agreementId2",
-        payeeAddr: "test_address2",
       });
       tests.add({
         id: "id3",
         amount: 100,
-        providerId: "providerId3",
+        provider: testProvider3,
         agreementId: "agreementId",
-        payeeAddr: "test_address3",
       });
       expect(tests.getByAgreementId("agreementId").count()).toEqual(2);
     });
@@ -277,12 +279,12 @@ describe("Stats Module", () => {
   describe("Proposals", () => {
     it("should beforeAdd() converts payload to ProposalInfo", async () => {
       const tests = new Proposals();
-      tests.add({ id: "id", providerId: "providerId" });
+      tests.add({ id: "id", providerId: testProvider.id });
       expect(tests.getAll()).toEqual(
         new Collection([
           {
             id: "id",
-            providerId: "providerId",
+            providerId: testProvider.id,
           },
         ]),
       );
@@ -290,11 +292,11 @@ describe("Stats Module", () => {
 
     it("should getByProviderId() return filtered Collection of ProposalInfo", async () => {
       const tests = new Proposals();
-      tests.add({ id: "id", providerId: "providerId" });
-      tests.add({ id: "id2", providerId: "providerId2" });
-      tests.add({ id: "id3", providerId: "providerId" });
-      expect(tests.getByProviderId("providerId")).toBeInstanceOf(Collection);
-      expect(tests.getByProviderId("providerId").count()).toEqual(2);
+      tests.add({ id: "id", providerId: testProvider.id });
+      tests.add({ id: "id2", providerId: testProvider2.id });
+      tests.add({ id: "id3", providerId: testProvider.id });
+      expect(tests.getByProviderId(testProvider.id)).toBeInstanceOf(Collection);
+      expect(tests.getByProviderId(testProvider.id).count()).toEqual(2);
     });
   });
   describe("Providers", () => {

--- a/tests/unit/stats_service.test.ts
+++ b/tests/unit/stats_service.test.ts
@@ -8,6 +8,11 @@ const eventTarget = new EventTarget();
 const statServiceOptions = { logger, eventTarget };
 setMaxListeners(20);
 
+const testProvider = {
+  id: "testId",
+  name: "test name",
+  walletAddress: "testWalletAddress",
+};
 describe("Stats Service", () => {
   let statsService: StatsService;
   beforeAll(async () => {
@@ -34,8 +39,7 @@ describe("Stats Service", () => {
         id: "taskId",
         agreementId: "agreementId",
         activityId: "activityId",
-        providerId: "providerId",
-        providerName: "providerName",
+        provider: testProvider,
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({
@@ -50,8 +54,7 @@ describe("Stats Service", () => {
         id: "taskId",
         agreementId: "agreementId",
         activityId: "activityId",
-        providerId: "providerId",
-        providerName: "providerName",
+        provider: testProvider,
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({ id: "activityId", taskId: "taskId", agreementId: "agreementId" });
@@ -63,8 +66,7 @@ describe("Stats Service", () => {
         agreementId: "agreementId",
         retriesCount: 1,
         activityId: "activityId",
-        providerId: "providerId",
-        providerName: "providerName",
+        provider: testProvider,
         reason: "reason",
       });
       eventTarget.dispatchEvent(event);
@@ -76,8 +78,7 @@ describe("Stats Service", () => {
         id: "id",
         agreementId: "agreementId",
         activityId: "activityId",
-        providerId: "providerId",
-        providerName: "providerName",
+        provider: testProvider,
         reason: "reason",
       });
 
@@ -103,41 +104,39 @@ describe("Stats Service", () => {
       const spy = jest.spyOn(statsService["proposals"], "add");
       const event = new Events.ProposalReceived({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
         parentId: null,
         details: {} as ProposalDetails,
       });
       eventTarget.dispatchEvent(event);
-      expect(spy).toHaveBeenCalledWith({ id: "id", providerId: "providerId" });
+      expect(spy).toHaveBeenCalledWith({ id: "id", providerId: testProvider.id });
     });
     it("should handle ProposalReceived and call Provider.add()", async () => {
       const spy = jest.spyOn(statsService["providers"], "add");
       const event = new Events.ProposalReceived({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
         parentId: null,
         details: {} as ProposalDetails,
       });
       eventTarget.dispatchEvent(event);
-      expect(spy).toHaveBeenCalledWith({ id: "providerId" });
+      expect(spy).toHaveBeenCalledWith({ id: testProvider.id });
     });
     // Invoices
     it("should handle InvoiceReceived and call Invoice.add()", async () => {
       const spy = jest.spyOn(statsService["invoices"], "add");
       const event = new Events.InvoiceReceived({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
         amount: 100,
-        payeeAddr: "test_address",
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
         amount: 100,
-        payeeAddr: "test_address",
       });
     });
     // Payments
@@ -145,18 +144,16 @@ describe("Stats Service", () => {
       const spy = jest.spyOn(statsService["payments"], "add");
       const event = new Events.PaymentAccepted({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
         amount: 100,
-        payeeAddr: "test_address",
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
         agreementId: "agreementId",
         amount: 100,
-        payeeAddr: "test_address",
       });
     });
     // Providers
@@ -164,30 +161,28 @@ describe("Stats Service", () => {
       const spy = jest.spyOn(statsService["providers"], "add");
       const event = new Events.AgreementCreated({
         id: "id",
-        providerId: "providerId",
-        providerName: "providerName",
+        provider: testProvider,
         proposalId: "proposalId",
       });
       eventTarget.dispatchEvent(event);
-      expect(spy).toHaveBeenCalledWith({ id: "providerId", providerName: "providerName" });
+      expect(spy).toHaveBeenCalledWith(testProvider);
     });
     // Agreements
     it("should handle AgreementCreated and call Agreements.add()", async () => {
       const spy = jest.spyOn(statsService["agreements"], "add");
       const event = new Events.AgreementCreated({
         id: "id",
-        providerId: "providerId",
-        providerName: "providerName",
+        provider: testProvider,
         proposalId: "proposalId",
       });
       eventTarget.dispatchEvent(event);
-      expect(spy).toHaveBeenCalledWith({ id: "id", providerId: "providerId", proposalId: "proposalId" });
+      expect(spy).toHaveBeenCalledWith({ id: "id", provider: testProvider, proposalId: "proposalId" });
     });
     it("should handle AgreementConfirmed and call Agreements.confirm()", async () => {
       const spy = jest.spyOn(statsService["agreements"], "confirm");
       const event = new Events.AgreementConfirmed({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith("id");
@@ -196,7 +191,7 @@ describe("Stats Service", () => {
       const spy = jest.spyOn(statsService["agreements"], "reject");
       const event = new Events.AgreementRejected({
         id: "id",
-        providerId: "providerId",
+        provider: testProvider,
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith("id");

--- a/tests/unit/stats_service.test.ts
+++ b/tests/unit/stats_service.test.ts
@@ -128,14 +128,16 @@ describe("Stats Service", () => {
         id: "id",
         providerId: "providerId",
         agreementId: "agreementId",
-        amount: "100",
+        amount: 100,
+        payeeAddr: "test_address",
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({
         id: "id",
         providerId: "providerId",
         agreementId: "agreementId",
-        amount: "100",
+        amount: 100,
+        payeeAddr: "test_address",
       });
     });
     // Payments
@@ -145,14 +147,16 @@ describe("Stats Service", () => {
         id: "id",
         providerId: "providerId",
         agreementId: "agreementId",
-        amount: "100",
+        amount: 100,
+        payeeAddr: "test_address",
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({
         id: "id",
         providerId: "providerId",
         agreementId: "agreementId",
-        amount: "100",
+        amount: 100,
+        payeeAddr: "test_address",
       });
     });
     // Providers


### PR DESCRIPTION
Evets that contained the `providerId` and/or `providerName` fields now return an object of the `ProviderInfo` type, which consists of `id`, `name` and `walletAddress`

By the way, I corrected the `amount` field, which was a string