### PR TITLE
Proposals batching

### DIFF
--- a/src/agreement/factory.ts
+++ b/src/agreement/factory.ts
@@ -45,7 +45,6 @@ export class AgreementFactory {
       const offerProperties: ProposalProperties = data.offer.properties as ProposalProperties;
       const demandProperties: ProposalProperties = data.demand.properties as ProposalProperties;
       const chosenPaymentPlatform = demandProperties["golem.com.payment.chosen-platform"];
-      console.log({ chosenPaymentPlatform });
       const provider = {
         name: offerProperties["golem.node.id.name"],
         id: data.offer.providerId,

--- a/src/market/demand.ts
+++ b/src/market/demand.ts
@@ -232,7 +232,6 @@ export class Demand extends EventTarget {
           const reason = error.response?.data?.message || error;
           this.options.eventTarget?.dispatchEvent(new Events.CollectFailed({ id: this.id, reason }));
           this.logger?.warn(`Unable to collect offers. ${reason}`);
-          console.log(error);
           if (error.code === "ECONNREFUSED" || error.response?.status === 404) {
             this.dispatchEvent(
               new DemandEvent(

--- a/src/market/demand.ts
+++ b/src/market/demand.ts
@@ -232,6 +232,7 @@ export class Demand extends EventTarget {
           const reason = error.response?.data?.message || error;
           this.options.eventTarget?.dispatchEvent(new Events.CollectFailed({ id: this.id, reason }));
           this.logger?.warn(`Unable to collect offers. ${reason}`);
+          console.log(error);
           if (error.code === "ECONNREFUSED" || error.response?.status === 404) {
             this.dispatchEvent(
               new DemandEvent(

--- a/src/market/proposal.test.ts
+++ b/src/market/proposal.test.ts
@@ -118,4 +118,22 @@ describe("Proposal", () => {
       });
     });
   });
+
+  describe("Estimating cost", () => {
+    test("it estimate cost based on CPU, Env and startup costs", () => {
+      const proposal = buildTestProposal({
+        "golem.inf.cpu.threads": 5,
+        "golem.com.usage.vector": ["golem.usage.duration_sec", "golem.usage.cpu_sec"],
+        "golem.com.pricing.model.linear.coeffs": [0.01, 0.02, 0.03],
+      });
+      expect(proposal.getEstimatedCost()).toEqual(0.14);
+    });
+    test("it estimate cost based on CPU, Env and startup costs if info about the number of threads is missing", () => {
+      const proposal = buildTestProposal({
+        "golem.com.usage.vector": ["golem.usage.duration_sec", "golem.usage.cpu_sec"],
+        "golem.com.pricing.model.linear.coeffs": [0.1, 0.2, 0.3],
+      });
+      expect(proposal.getEstimatedCost()).toEqual(0.6);
+    });
+  });
 });

--- a/src/market/proposal.ts
+++ b/src/market/proposal.ts
@@ -246,6 +246,14 @@ export class Proposal {
     return this.getProviderPaymentPlatforms().includes(paymentPlatform);
   }
 
+  /**
+   * Proposal cost estimation based on CPU, Env and startup costs
+   */
+  getEstimatedCost(): number {
+    const threadsNo = this.properties["golem.inf.cpu.threads"] || 1;
+    return this.pricing.start + this.pricing.cpuSec * threadsNo + this.pricing.envSec;
+  }
+
   private getProviderPaymentPlatforms(): string[] {
     return (
       Object.keys(this.properties)

--- a/src/market/proposals_batch.test.ts
+++ b/src/market/proposals_batch.test.ts
@@ -17,10 +17,10 @@ describe("ProposalsBatch", () => {
       } as ProposalProperties);
       const proposal = instance(mockedProposal);
       await proposalsBatch.addProposal(proposal);
-      expect(await proposalsBatch.getProposals()).toContainEqual(proposal);
+      expect((await proposalsBatch.readProposals().next()).value).toContainEqual(proposal);
     });
     it("should add the proposal to the batch from the existing provider and the same hardware configuration", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeout: 100 });
+      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
       const mockedProposal = mock(Proposal);
       when(mockedProposal.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal.properties).thenReturn({
@@ -33,7 +33,7 @@ describe("ProposalsBatch", () => {
       const proposal2 = instance(mockedProposal);
       await proposalsBatch.addProposal(proposal1);
       await proposalsBatch.addProposal(proposal2);
-      const proposals = await proposalsBatch.getProposals();
+      const proposals = (await proposalsBatch.readProposals().next()).value;
       expect(proposals.length).toEqual(1);
     });
 
@@ -59,7 +59,7 @@ describe("ProposalsBatch", () => {
       const proposal2 = instance(mockedProposal2);
       await proposalsBatch.addProposal(proposal1);
       await proposalsBatch.addProposal(proposal2);
-      const proposals = await proposalsBatch.getProposals();
+      const proposals = (await proposalsBatch.readProposals().next()).value;
       expect(proposals.length).toEqual(2);
       expect(proposals).toContainEqual(proposal1);
       expect(proposals).toContainEqual(proposal2);
@@ -67,7 +67,7 @@ describe("ProposalsBatch", () => {
   });
   describe("Getting Proposals", () => {
     it("should get the set of proposals grouped by provider key distinguished by provider id, cpu, threads, memory and storage", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeout: 100 });
+      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
       const mockedProposal1 = mock(Proposal);
       when(mockedProposal1.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal1.properties).thenReturn({
@@ -129,7 +129,7 @@ describe("ProposalsBatch", () => {
         proposalsBatch.addProposal(proposal5),
         proposalsBatch.addProposal(proposal6),
       ]);
-      const proposals = await proposalsBatch.getProposals();
+      const proposals = (await proposalsBatch.readProposals().next()).value;
       expect(proposals.length).toEqual(5);
       expect(proposals).toContainEqual(proposal1);
       expect(proposals).not.toContainEqual(proposal2);
@@ -139,7 +139,7 @@ describe("ProposalsBatch", () => {
       expect(proposals).toContainEqual(proposal6);
     });
     it("should get the set of proposal grouped by provider key and reduced by the lowest price and highest time", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeout: 100 });
+      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
       const mockedProposal1 = mock(Proposal);
       when(mockedProposal1.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal1.properties).thenReturn({
@@ -188,14 +188,14 @@ describe("ProposalsBatch", () => {
       await proposalsBatch.addProposal(proposal1);
       await proposalsBatch.addProposal(proposal2);
       await proposalsBatch.addProposal(proposal3);
-      const proposals = await proposalsBatch.getProposals();
+      const proposals = (await proposalsBatch.readProposals().next()).value;
       expect(proposals.length).toEqual(1);
       expect(proposals).toContainEqual(proposal2);
       expect(proposals).not.toContainEqual(proposal1);
       expect(proposals).not.toContainEqual(proposal3);
     });
     it("should drain batch after getting proposals", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeout: 100 });
+      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
       const mockedProposal = mock(Proposal);
       when(mockedProposal.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal.properties).thenReturn({
@@ -206,12 +206,12 @@ describe("ProposalsBatch", () => {
       } as ProposalProperties);
       const proposal = instance(mockedProposal);
       await proposalsBatch.addProposal(proposal);
-      expect((await proposalsBatch.getProposals()).length).toEqual(1);
-      expect((await proposalsBatch.getProposals()).length).toEqual(0);
+      expect((await proposalsBatch.readProposals().next()).value.length).toEqual(1);
+      expect((await proposalsBatch.readProposals().next()).value.length).toEqual(0);
       await proposalsBatch.addProposal(proposal);
       await proposalsBatch.addProposal(proposal);
-      expect((await proposalsBatch.getProposals()).length).toEqual(1);
-      expect((await proposalsBatch.getProposals()).length).toEqual(0);
+      expect((await proposalsBatch.readProposals().next()).value.length).toEqual(1);
+      expect((await proposalsBatch.readProposals().next()).value.length).toEqual(0);
     });
   });
 });

--- a/src/market/proposals_batch.test.ts
+++ b/src/market/proposals_batch.test.ts
@@ -1,0 +1,37 @@
+import { ProposalsBatch } from "./proposals_batch";
+import { mock, instance, when } from "@johanblumenberg/ts-mockito";
+import { Proposal } from "./proposal";
+
+describe("ProposalsBatch", () => {
+  describe("Adding Proposals", () => {
+    it("should add the proposal to the batch from the new provider", async () => {
+      const mockedProposal = mock(Proposal);
+      when(mockedProposal.issuerId).thenReturn("provider1");
+      const proposal = instance(mockedProposal);
+      const proposalsBatch = new ProposalsBatch();
+      proposalsBatch.addProposal(proposal);
+      expect(proposalsBatch.getProposals()).toContainEqual(proposal);
+    });
+    it("should add the proposal to the batch from the existing provider", async () => {
+      const proposalsBatch = new ProposalsBatch();
+      const mockedProposal1 = mock(Proposal);
+      when(mockedProposal1.issuerId).thenReturn("provider1");
+      const mockedProposal2 = mock(Proposal);
+      when(mockedProposal2.issuerId).thenReturn("provider1");
+      when(mockedProposal2.pricing).thenReturn({
+        cpuSec: 2,
+        envSec: 3,
+        start: 1,
+      });
+      const proposal1 = instance(mockedProposal1);
+      const proposal2 = instance(mockedProposal1);
+      proposalsBatch.addProposal(proposal1);
+      proposalsBatch.addProposal(proposal2);
+      expect(proposalsBatch.getProposals()).toContainEqual(proposal2);
+      expect(proposalsBatch.getProposals()).not.toContainEqual(proposal1);
+    });
+  });
+  describe("Getting Proposals", () => {
+    it.todo("should get the set of proposal grouped by provider id and sorted by price", async () => {});
+  });
+});

--- a/src/market/proposals_batch.test.ts
+++ b/src/market/proposals_batch.test.ts
@@ -1,37 +1,37 @@
-import { ProposalsBatch } from "./proposals_batch";
-import { mock, instance, when } from "@johanblumenberg/ts-mockito";
-import { Proposal } from "./proposal";
-
-describe("ProposalsBatch", () => {
-  describe("Adding Proposals", () => {
-    it("should add the proposal to the batch from the new provider", async () => {
-      const mockedProposal = mock(Proposal);
-      when(mockedProposal.issuerId).thenReturn("provider1");
-      const proposal = instance(mockedProposal);
-      const proposalsBatch = new ProposalsBatch();
-      proposalsBatch.addProposal(proposal);
-      expect(proposalsBatch.getProposals()).toContainEqual(proposal);
-    });
-    it("should add the proposal to the batch from the existing provider", async () => {
-      const proposalsBatch = new ProposalsBatch();
-      const mockedProposal1 = mock(Proposal);
-      when(mockedProposal1.issuerId).thenReturn("provider1");
-      const mockedProposal2 = mock(Proposal);
-      when(mockedProposal2.issuerId).thenReturn("provider1");
-      when(mockedProposal2.pricing).thenReturn({
-        cpuSec: 2,
-        envSec: 3,
-        start: 1,
-      });
-      const proposal1 = instance(mockedProposal1);
-      const proposal2 = instance(mockedProposal1);
-      proposalsBatch.addProposal(proposal1);
-      proposalsBatch.addProposal(proposal2);
-      expect(proposalsBatch.getProposals()).toContainEqual(proposal2);
-      expect(proposalsBatch.getProposals()).not.toContainEqual(proposal1);
-    });
-  });
-  describe("Getting Proposals", () => {
-    it.todo("should get the set of proposal grouped by provider id and sorted by price", async () => {});
-  });
-});
+// import { ProposalsBatch } from "./proposals_batch";
+// import { mock, instance, when } from "@johanblumenberg/ts-mockito";
+// import { Proposal } from "./proposal";
+//
+// describe("ProposalsBatch", () => {
+//   describe("Adding Proposals", () => {
+//     it("should add the proposal to the batch from the new provider", async () => {
+//       const mockedProposal = mock(Proposal);
+//       when(mockedProposal.issuerId).thenReturn("provider1");
+//       const proposal = instance(mockedProposal);
+//       const proposalsBatch = new ProposalsBatch();
+//       proposalsBatch.addProposal(proposal);
+//       expect(proposalsBatch.getProposals()).toContainEqual(proposal);
+//     });
+//     it("should add the proposal to the batch from the existing provider", async () => {
+//       const proposalsBatch = new ProposalsBatch();
+//       const mockedProposal1 = mock(Proposal);
+//       when(mockedProposal1.issuerId).thenReturn("provider1");
+//       const mockedProposal2 = mock(Proposal);
+//       when(mockedProposal2.issuerId).thenReturn("provider1");
+//       when(mockedProposal2.pricing).thenReturn({
+//         cpuSec: 2,
+//         envSec: 3,
+//         start: 1,
+//       });
+//       const proposal1 = instance(mockedProposal1);
+//       const proposal2 = instance(mockedProposal1);
+//       proposalsBatch.addProposal(proposal1);
+//       proposalsBatch.addProposal(proposal2);
+//       expect(proposalsBatch.getProposals()).toContainEqual(proposal2);
+//       expect(proposalsBatch.getProposals()).not.toContainEqual(proposal1);
+//     });
+//   });
+//   describe("Getting Proposals", () => {
+//     it.todo("should get the set of proposal grouped by provider id and sorted by price", async () => {});
+//   });
+// });

--- a/src/market/proposals_batch.test.ts
+++ b/src/market/proposals_batch.test.ts
@@ -3,12 +3,18 @@ import { mock, instance, when } from "@johanblumenberg/ts-mockito";
 import { Proposal, ProposalProperties } from "./proposal";
 import { ProviderInfo } from "../agreement";
 
+const mockedProviderInfo: ProviderInfo = {
+  id: "provider-id-1",
+  name: "provider-name-1",
+  walletAddress: "0x1234566789",
+};
+
 describe("ProposalsBatch", () => {
   describe("Adding Proposals", () => {
     it("should add the proposal to the batch from new provider", async () => {
       const proposalsBatch = new ProposalsBatch({ minBatchSize: 1 });
       const mockedProposal = mock(Proposal);
-      when(mockedProposal.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -22,7 +28,7 @@ describe("ProposalsBatch", () => {
     it("should not add the proposal to the batch from the existing provider and the same hardware configuration", async () => {
       const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal = mock(Proposal);
-      when(mockedProposal.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -40,7 +46,7 @@ describe("ProposalsBatch", () => {
     it("should add the proposal to the batch from the existing provider and different hardware configuration", async () => {
       const proposalsBatch = new ProposalsBatch({ minBatchSize: 2 });
       const mockedProposal1 = mock(Proposal);
-      when(mockedProposal1.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal1.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal1.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -48,7 +54,7 @@ describe("ProposalsBatch", () => {
         ["golem.inf.storage.gib"]: 1,
       } as ProposalProperties);
       const mockedProposal2 = mock(Proposal);
-      when(mockedProposal2.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal2.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal2.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 77,
         ["golem.inf.cpu.threads"]: 77,
@@ -65,11 +71,11 @@ describe("ProposalsBatch", () => {
       expect(proposals).toContainEqual(proposal2);
     });
   });
-  describe("Getting Proposals", () => {
-    it("should get the set of proposals grouped by provider key distinguished by provider id, cpu, threads, memory and storage", async () => {
+  describe("Reading Proposals", () => {
+    it("should read the set of proposals grouped by provider key distinguished by provider id, cpu, threads, memory and storage", async () => {
       const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal1 = mock(Proposal);
-      when(mockedProposal1.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal1.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal1.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -77,7 +83,7 @@ describe("ProposalsBatch", () => {
         ["golem.inf.storage.gib"]: 1,
       } as ProposalProperties);
       const mockedProposal2 = mock(Proposal);
-      when(mockedProposal2.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal2.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal2.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -85,7 +91,7 @@ describe("ProposalsBatch", () => {
         ["golem.inf.storage.gib"]: 1,
       } as ProposalProperties);
       const mockedProposal3 = mock(Proposal);
-      when(mockedProposal3.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal3.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal3.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 77,
@@ -93,7 +99,7 @@ describe("ProposalsBatch", () => {
         ["golem.inf.storage.gib"]: 1,
       } as ProposalProperties);
       const mockedProposal4 = mock(Proposal);
-      when(mockedProposal4.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal4.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal4.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -101,7 +107,7 @@ describe("ProposalsBatch", () => {
         ["golem.inf.storage.gib"]: 1,
       } as ProposalProperties);
       const mockedProposal5 = mock(Proposal);
-      when(mockedProposal5.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal5.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal5.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -138,10 +144,10 @@ describe("ProposalsBatch", () => {
       expect(proposals).toContainEqual(proposal5);
       expect(proposals).toContainEqual(proposal6);
     });
-    it("should get the set of proposal grouped by provider key and reduced to the lowest price and highest time", async () => {
+    it("should read the set of proposal grouped by provider key and reduced proposals from teh same provider to the lowest price and highest time", async () => {
       const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal1 = mock(Proposal);
-      when(mockedProposal1.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal1.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal1.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -155,7 +161,7 @@ describe("ProposalsBatch", () => {
       });
       when(mockedProposal1.timestamp).thenReturn("2024-01-01T00:00:00.000Z");
       const mockedProposal2 = mock(Proposal);
-      when(mockedProposal2.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal2.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal2.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -169,7 +175,7 @@ describe("ProposalsBatch", () => {
       });
       when(mockedProposal2.timestamp).thenReturn("2024-01-01T07:07:07.007Z");
       const mockedProposal3 = mock(Proposal);
-      when(mockedProposal3.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal3.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal3.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,
@@ -194,10 +200,10 @@ describe("ProposalsBatch", () => {
       expect(proposals).not.toContainEqual(proposal1);
       expect(proposals).not.toContainEqual(proposal3);
     });
-    it("should drain batch after getting proposals", async () => {
+    it("should drain batch after reading proposals", async () => {
       const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal = mock(Proposal);
-      when(mockedProposal.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
+      when(mockedProposal.provider).thenReturn(mockedProviderInfo);
       when(mockedProposal.properties).thenReturn({
         ["golem.inf.cpu.cores"]: 1,
         ["golem.inf.cpu.threads"]: 1,

--- a/src/market/proposals_batch.test.ts
+++ b/src/market/proposals_batch.test.ts
@@ -19,8 +19,8 @@ describe("ProposalsBatch", () => {
       await proposalsBatch.addProposal(proposal);
       expect((await proposalsBatch.readProposals().next()).value).toContainEqual(proposal);
     });
-    it("should add the proposal to the batch from the existing provider and the same hardware configuration", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
+    it("should not add the proposal to the batch from the existing provider and the same hardware configuration", async () => {
+      const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal = mock(Proposal);
       when(mockedProposal.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal.properties).thenReturn({
@@ -67,7 +67,7 @@ describe("ProposalsBatch", () => {
   });
   describe("Getting Proposals", () => {
     it("should get the set of proposals grouped by provider key distinguished by provider id, cpu, threads, memory and storage", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
+      const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal1 = mock(Proposal);
       when(mockedProposal1.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal1.properties).thenReturn({
@@ -138,8 +138,8 @@ describe("ProposalsBatch", () => {
       expect(proposals).toContainEqual(proposal5);
       expect(proposals).toContainEqual(proposal6);
     });
-    it("should get the set of proposal grouped by provider key and reduced by the lowest price and highest time", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
+    it("should get the set of proposal grouped by provider key and reduced to the lowest price and highest time", async () => {
+      const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal1 = mock(Proposal);
       when(mockedProposal1.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal1.properties).thenReturn({
@@ -195,7 +195,7 @@ describe("ProposalsBatch", () => {
       expect(proposals).not.toContainEqual(proposal3);
     });
     it("should drain batch after getting proposals", async () => {
-      const proposalsBatch = new ProposalsBatch({ timeoutMs: 100 });
+      const proposalsBatch = new ProposalsBatch({ releaseTimeoutMs: 100 });
       const mockedProposal = mock(Proposal);
       when(mockedProposal.provider).thenReturn({ id: "provider-1" } as ProviderInfo);
       when(mockedProposal.properties).thenReturn({

--- a/src/market/proposals_batch.ts
+++ b/src/market/proposals_batch.ts
@@ -79,8 +79,8 @@ export class ProposalsBatch {
    */
   private getBestProposal(proposals: Set<Proposal>): Proposal {
     const sortByLowerPriceAndHigherTime = (p1: Proposal, p2: Proposal) => {
-      const p1Price = this.estimatePrice(p1);
-      const p2Price = this.estimatePrice(p2);
+      const p1Price = p1.getEstimatedCost();
+      const p2Price = p2.getEstimatedCost();
       const p1Time = new Date(p1.timestamp).valueOf();
       const p2Time = new Date(p2.timestamp).valueOf();
       return p1Price !== p2Price ? p1Price - p2Price : p2Time - p1Time;
@@ -99,13 +99,5 @@ export class ProposalsBatch {
       proposal.properties["golem.inf.mem.gib"],
       proposal.properties["golem.inf.storage.gib"],
     ].join("-");
-  }
-
-  /**
-   * Proposal price estimation based on CPU, Env and startup costs
-   */
-  private estimatePrice(proposal: Proposal): number {
-    const threadsNo = proposal.properties["golem.inf.cpu.threads"];
-    return proposal.pricing.start + proposal.pricing.cpuSec * threadsNo + proposal.pricing.envSec;
   }
 }

--- a/src/market/proposals_batch.ts
+++ b/src/market/proposals_batch.ts
@@ -1,0 +1,24 @@
+import { Proposal } from "./proposal";
+
+export class ProposalsBatch {
+  private batch = new Map<string, Set<Proposal>>();
+  addProposal(proposal: Proposal) {
+    const proposals = this.batch.get(proposal.issuerId) || new Set<Proposal>();
+    this.batch.set(proposal.issuerId, proposals);
+    proposals.add(proposal);
+  }
+
+  getProposals(): Proposal[] {
+    const proposals: Proposal[] = [];
+    this.batch.forEach((providersProposals) => proposals.push(this.getBestProposalForProvider(providersProposals)));
+    return proposals;
+  }
+
+  private getBestProposalForProvider(providersProposals: Set<Proposal>): Proposal {
+    const sortByPrice = (p1: Proposal, p2: Proposal): number => {
+      if (p1.pricing.cpuSec >= p2.pricing.cpuSec) return 1;
+      return -1;
+    };
+    return [...providersProposals].sort(sortByPrice)[0];
+  }
+}

--- a/src/market/proposals_batch.ts
+++ b/src/market/proposals_batch.ts
@@ -5,12 +5,12 @@ export type ProposalsBatchOptions = {
   /** The minimum number of proposals after which it will be possible to return the collection */
   minBatchSize?: number;
   /** The maximum waiting time for collecting proposals after which it will be possible to return the collection */
-  timeoutMs?: number;
+  releaseTimeoutMs?: number;
 };
 
 const DEFAULTS = {
   minBatchSize: 100,
-  timeout: 1_000,
+  releaseTimeoutMs: 1_000,
 };
 
 /**
@@ -27,7 +27,7 @@ export class ProposalsBatch {
   constructor(options?: ProposalsBatchOptions) {
     this.config = {
       minBatchSize: options?.minBatchSize ?? DEFAULTS.minBatchSize,
-      timeoutMs: options?.timeoutMs ?? DEFAULTS.timeout,
+      releaseTimeoutMs: options?.releaseTimeoutMs ?? DEFAULTS.releaseTimeoutMs,
     };
   }
 
@@ -54,14 +54,14 @@ export class ProposalsBatch {
   async *readProposals(): AsyncGenerator<Proposal[]> {
     let timeoutId, intervalId;
     const isTimeoutReached = new Promise((resolve) => {
-      timeoutId = setTimeout(resolve, this.config.timeoutMs);
+      timeoutId = setTimeout(resolve, this.config.releaseTimeoutMs);
     });
     const isBatchSizeReached = new Promise((resolve) => {
       intervalId = setInterval(() => {
         if (this.batch.size >= this.config.minBatchSize) {
           resolve(true);
         }
-      });
+      }, 1_000);
     });
     await Promise.race([isTimeoutReached, isBatchSizeReached]);
     clearTimeout(timeoutId);

--- a/src/market/proposals_batch.ts
+++ b/src/market/proposals_batch.ts
@@ -26,6 +26,7 @@ export class ProposalsBatch {
   /** Lock used to synchronize adding and getting proposals from the batch */
   private lock: AsyncLock = new AsyncLock();
   private config: Required<ProposalsBatchOptions>;
+
   constructor(options?: ProposalsBatchOptions) {
     this.config = {
       minBatchSize: options?.minBatchSize ?? DEFAULTS.minBatchSize,

--- a/src/market/proposals_batch.ts
+++ b/src/market/proposals_batch.ts
@@ -1,24 +1,67 @@
 import { Proposal } from "./proposal";
+import AsyncLock from "async-lock";
 
 export class ProposalsBatch {
   private batch = new Map<string, Set<Proposal>>();
-  addProposal(proposal: Proposal) {
-    const proposals = this.batch.get(proposal.issuerId) || new Set<Proposal>();
-    this.batch.set(proposal.issuerId, proposals);
-    proposals.add(proposal);
+  private lock: AsyncLock = new AsyncLock();
+  constructor(private config: { minBatchSize: number; timeout: number; expirationSec: number }) {}
+
+  async addProposal(proposal: Proposal) {
+    const providerKey = this.getProviderKey(proposal);
+    const proposals = this.batch.get(providerKey) || new Set<Proposal>();
+    await this.lock.acquire("app", () => {
+      this.batch.set(providerKey, proposals);
+      proposals.add(proposal);
+    });
   }
 
-  getProposals(): Proposal[] {
-    const proposals: Proposal[] = [];
-    this.batch.forEach((providersProposals) => proposals.push(this.getBestProposalForProvider(providersProposals)));
-    return proposals;
+  async getProposals(): Promise<Proposal[]> {
+    return new Promise((resolve) => {
+      const startTime = Date.now();
+      const intervalId = setInterval(async () => {
+        const isTimeoutReached = Date.now() - startTime >= this.config.timeout;
+        if (this.batch.size >= this.config.minBatchSize || isTimeoutReached) {
+          const proposals: Proposal[] = [];
+          await this.lock.acquire("app", () => {
+            this.batch.forEach((providersProposals) => proposals.push(this.getBestProposal(providersProposals)));
+            this.batch.clear();
+          });
+          resolve(proposals);
+          clearInterval(intervalId);
+        }
+      }, 1_000);
+    });
   }
 
-  private getBestProposalForProvider(providersProposals: Set<Proposal>): Proposal {
-    const sortByPrice = (p1: Proposal, p2: Proposal): number => {
-      if (p1.pricing.cpuSec >= p2.pricing.cpuSec) return 1;
-      return -1;
+  private getBestProposal(proposals: Set<Proposal>): Proposal {
+    const sortByLowerPriceAndHigherTime = (p1: Proposal, p2: Proposal) => {
+      const p1Price = this.estimatePrice(p1);
+      const p2Price = this.estimatePrice(p2);
+      const p1Time = new Date(p1.timestamp).valueOf();
+      const p2Time = new Date(p2.timestamp).valueOf();
+      return p1Price !== p2Price ? p1Price - p2Price : p2Time - p1Time;
     };
-    return [...providersProposals].sort(sortByPrice)[0];
+    return [...proposals].sort(sortByLowerPriceAndHigherTime)[0];
+  }
+
+  private getProviderKey(proposal: Proposal): string {
+    return [
+      proposal.provider.id,
+      proposal.properties["golem.inf.cpu.cores"],
+      proposal.properties["golem.inf.cpu.threads"],
+      proposal.properties["golem.inf.mem.gib"],
+      proposal.properties["golem.inf.storage.gib"],
+    ].join("-");
+  }
+
+  private estimatePrice(proposal: Proposal): number {
+    const maxDurationSec = this.config.expirationSec;
+    const threadsNo = proposal.properties["golem.inf.cpu.threads"];
+
+    return (
+      proposal.pricing.start +
+      proposal.pricing.cpuSec * threadsNo * maxDurationSec +
+      proposal.pricing.envSec * maxDurationSec
+    );
   }
 }

--- a/src/market/proposals_batch.ts
+++ b/src/market/proposals_batch.ts
@@ -48,7 +48,7 @@ export class ProposalsBatch {
   }
 
   /**
-   * Returns a set of proposals that were collected within the specified `timeoutMs`
+   * Generates a set of proposals that were collected within the specified `releaseTimeoutMs`
    * or their size reached the `minBatchSize` value
    */
   async *readProposals(): AsyncGenerator<Proposal[]> {

--- a/src/market/service.ts
+++ b/src/market/service.ts
@@ -47,9 +47,9 @@ export class MarketService {
     this.options = new MarketConfig(options);
     this.logger = this.options?.logger;
     this.proposalsBatch = new ProposalsBatch({
-      minBatchSize: options?.minProposalsBatchSize ?? 100,
-      timeout: options?.proposalsBatchTimeout ?? 2_000,
-      expirationSec: options?.expirationSec ?? 30 * 60,
+      minBatchSize: options?.minProposalsBatchSize,
+      timeout: options?.proposalsBatchTimeout,
+      expirationSec: options?.expirationSec,
     });
   }
 

--- a/src/market/service.ts
+++ b/src/market/service.ts
@@ -11,7 +11,10 @@ import { ProposalsBatch } from "./proposals_batch";
 export type ProposalFilter = (proposal: Proposal) => Promise<boolean> | boolean;
 
 export interface MarketOptions extends DemandOptions {
-  /** A custom filter that checks every proposal coming from the market */
+  /**
+   * A custom filter checking the proposal from the market for each provider and its hardware configuration.
+   * Duplicate proposals from one provider are reduced to the cheapest one.
+   */
   proposalFilter?: ProposalFilter;
   /** The minimum number of proposals after which the batch of proposal will be processed in order to avoid duplicates */
   minProposalsBatchSize?: number;

--- a/src/market/service.ts
+++ b/src/market/service.ts
@@ -175,6 +175,7 @@ export class MarketService {
       const proposals = await this.proposalsBatch.getProposals();
       proposals.forEach((proposal) => this.processInitialProposal(proposal));
     };
+    processProposalsBatch().then();
     this.batchIntervalId = setInterval(processProposalsBatch, 1_000);
   }
 }

--- a/src/market/service.ts
+++ b/src/market/service.ts
@@ -13,9 +13,9 @@ export type ProposalFilter = (proposal: Proposal) => Promise<boolean> | boolean;
 export interface MarketOptions extends DemandOptions {
   /** A custom filter that checks every proposal coming from the market */
   proposalFilter?: ProposalFilter;
-  /** TODO */
+  /** The minimum number of proposals after which the batch of proposal will be processed in order to avoid duplicates */
   minProposalsBatchSize?: number;
-  /** TODO */
+  /** The maximum waiting time for proposals to be batched in order to avoid duplicates */
   proposalsBatchTimeout?: number;
 }
 
@@ -57,7 +57,7 @@ export class MarketService {
     this.taskPackage = taskPackage;
     this.allocation = allocation;
     await this.createDemand();
-    this.startProcessingBatchProposals();
+    this.startProcessingProposalsBatch();
     this.logger?.debug("Market Service has started");
   }
 
@@ -170,11 +170,11 @@ export class MarketService {
     );
   }
 
-  private startProcessingBatchProposals() {
-    const processBatchProposals = async () => {
+  private startProcessingProposalsBatch() {
+    const processProposalsBatch = async () => {
       const proposals = await this.proposalsBatch.getProposals();
       proposals.forEach((proposal) => this.processInitialProposal(proposal));
     };
-    this.batchIntervalId = setInterval(processBatchProposals, 1_000);
+    this.batchIntervalId = setInterval(processProposalsBatch, 1_000);
   }
 }

--- a/src/market/service.ts
+++ b/src/market/service.ts
@@ -16,7 +16,7 @@ export interface MarketOptions extends DemandOptions {
   /** The minimum number of proposals after which the batch of proposal will be processed in order to avoid duplicates */
   minProposalsBatchSize?: number;
   /** The maximum waiting time for proposals to be batched in order to avoid duplicates */
-  proposalsBatchTimeoutMs?: number;
+  proposalsBatchReleaseTimeoutMs?: number;
 }
 
 /**
@@ -48,7 +48,7 @@ export class MarketService {
     this.logger = this.options?.logger;
     this.proposalsBatch = new ProposalsBatch({
       minBatchSize: options?.minProposalsBatchSize,
-      timeoutMs: options?.proposalsBatchTimeoutMs,
+      releaseTimeoutMs: options?.proposalsBatchReleaseTimeoutMs,
     });
   }
 

--- a/tests/unit/market_service.test.ts
+++ b/tests/unit/market_service.test.ts
@@ -29,7 +29,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -51,7 +51,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals([proposalsInitial[6]]);
@@ -63,7 +63,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsWrongPaymentPlatform);
@@ -74,7 +74,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsShortDebitNoteTimeout);
@@ -87,7 +87,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: proposalAlwaysBanFilter,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -99,7 +99,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.blackListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -111,7 +111,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.blackListProposalRegexpFilter(/golem2004/),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -123,7 +123,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0x123455"]),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -135,7 +135,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/abcdefg/),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -147,7 +147,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -159,7 +159,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/golem2004/),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeoutMs: 10,
+      proposalsBatchReleaseTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);

--- a/tests/unit/market_service.test.ts
+++ b/tests/unit/market_service.test.ts
@@ -26,7 +26,11 @@ describe("Market Service", () => {
   });
 
   it("should respond initial proposal", async () => {
-    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, { logger });
+    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
+      logger,
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
+    });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
     await logger.expectToInclude("Proposal has been responded", 10);
@@ -44,7 +48,11 @@ describe("Market Service", () => {
   });
 
   it("should reject initial proposal without common payment platform", async () => {
-    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, { logger });
+    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
+      logger,
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
+    });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals([proposalsInitial[6]]);
     await logger.expectToMatch(/Proposal has been rejected .* Reason: No common payment platform/, 10);
@@ -52,14 +60,22 @@ describe("Market Service", () => {
   });
 
   it("should reject when no common payment platform", async () => {
-    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, { logger });
+    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
+      logger,
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
+    });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsWrongPaymentPlatform);
     await logger.expectToMatch(/No common payment platform/, 10);
     await marketService.end();
   });
   it("should reject initial proposal when debit note acceptance timeout too short", async () => {
-    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, { logger });
+    const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
+      logger,
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
+    });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsShortDebitNoteTimeout);
     await logger.expectToMatch(/Debit note acceptance timeout too short/, 10);
@@ -70,6 +86,8 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: proposalAlwaysBanFilter,
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -80,6 +98,8 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: ProposalFilters.blackListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -90,6 +110,8 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: ProposalFilters.blackListProposalRegexpFilter(/golem2004/),
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -100,6 +122,8 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0x123455"]),
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -110,6 +134,8 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/abcdefg/),
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -120,6 +146,8 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -130,6 +158,8 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/golem2004/),
+      minProposalsBatchSize: 1,
+      proposalsBatchTimeout: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);

--- a/tests/unit/market_service.test.ts
+++ b/tests/unit/market_service.test.ts
@@ -29,7 +29,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -51,7 +51,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals([proposalsInitial[6]]);
@@ -63,7 +63,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsWrongPaymentPlatform);
@@ -74,7 +74,7 @@ describe("Market Service", () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsShortDebitNoteTimeout);
@@ -87,7 +87,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: proposalAlwaysBanFilter,
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -99,7 +99,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.blackListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -111,7 +111,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.blackListProposalRegexpFilter(/golem2004/),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -123,7 +123,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0x123455"]),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -135,7 +135,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/abcdefg/),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -147,7 +147,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);
@@ -159,7 +159,7 @@ describe("Market Service", () => {
       logger,
       proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/golem2004/),
       minProposalsBatchSize: 1,
-      proposalsBatchTimeout: 10,
+      proposalsBatchTimeoutMs: 10,
     });
     await marketService.run(packageMock, allocationMock);
     setExpectedProposals(proposalsInitial);


### PR DESCRIPTION
This PR contains a new class `ProposalsBatch` which is used to group Initial Proposals. Each Initial Proposal received in `MarketService` is added to Batch, then at an interval the proposals are fetched grouped according to the provider key distinguished by provider ID and hardware configuration in order to avoid duplication of offers.