### PR TITLE
Ci pipeline test logs fix

### DIFF
--- a/.github/actions/cleanup-tests/action.yml
+++ b/.github/actions/cleanup-tests/action.yml
@@ -1,5 +1,10 @@
 name: "Cleanup test environment"
 description: "Cleanup test environment"
+inputs:
+  type:
+    description: "Type of test"
+    required: true
+    default: "test"
 runs:
   using: "composite"
   steps:
@@ -8,9 +13,9 @@ runs:
       if: always()
       run: |
         mkdir log-output
-        docker compose -f tests/docker/docker-compose.yml logs provider-1 > log-output/provider-1.log
-        docker compose -f tests/docker/docker-compose.yml logs provider-2 > log-output/provider-2.log
-        docker compose -f tests/docker/docker-compose.yml logs requestor > log-output/requestor.log
+        docker compose -f tests/docker/docker-compose.yml logs provider-1 > log-output/${{inputs.type}}-provider-1.log
+        docker compose -f tests/docker/docker-compose.yml logs provider-2 > log-output/${{inputs.type}}-provider-2.log
+        docker compose -f tests/docker/docker-compose.yml logs requestor > log-output/${{inputs.type}}-requestor.log
 
     - name: Upload provider output and logs
       uses: actions/upload-artifact@v3

--- a/.github/actions/cleanup-tests/action.yml
+++ b/.github/actions/cleanup-tests/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: golem-provider-and-requestor-logs
+        name: ${{inputs.type}}-golem-provider-and-requestor-logs
         path: log-output
 
     - name: Cleanup Docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Cleanup test environment
         uses: ./.github/actions/cleanup-tests
+        with:
+          type: "e2e"
 
   run-cypress-tests:
     name: Run Cypress tests
@@ -127,6 +129,8 @@ jobs:
 
       - name: Cleanup test environment
         uses: ./.github/actions/cleanup-tests
+        with:
+          type: "cypress"
 
   run-examples-tests:
     name: Run Examples tests
@@ -143,6 +147,8 @@ jobs:
 
       - name: Cleanup test environment
         uses: ./.github/actions/cleanup-tests
+        with:
+          type: "examples"
 
   release:
     name: Release the SDK to NPM and GitHub


### PR DESCRIPTION
Fixed log generation from yagna for requestr and providers during e2e, cypress and examples tests. Now there are separate packages for each type of tests