### PR TITLE
fix(market): all proposal filters are no longer async and have been r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ details.
 ### Limit price limits to filter out offers that are too expensive
 
 ```typescript
-import { TaskExecutor, ProposalFilters } from "@golem-sdk/golem-js";
+import { TaskExecutor, ProposalFilterFactory } from "@golem-sdk/golem-js";
 
 const executor = await TaskExecutor.create({
   // What do you want to run
@@ -159,7 +159,7 @@ const executor = await TaskExecutor.create({
 
   // How much you wish to spend
   budget: 0.5,
-  proposalFilter: ProposalFilters.limitPriceFilter({
+  proposalFilter: ProposalFilterFactory.limitPriceFilter({
     start: 1,
     cpuPerSec: 1 / 3600,
     envPerSec: 1 / 3600,
@@ -182,20 +182,20 @@ health-checks. Using this whitelist will increase the chance of working with a r
 can also build up your own list of favourite providers and use it in a similar fashion.
 
 ```typescript
-import { TaskExecutor, ProposalFilters, MarketHelpers } from "@golem-sdk/golem-js";
-
-// Prepare the price filter
-const acceptablePrice = ProposalFilters.limitPriceFilter({
-  start: 1,
-  cpuPerSec: 1 / 3600,
-  envPerSec: 1 / 3600,
-});
+import { MarketHelpers, ProposalFilterFactory, TaskExecutor } from "@golem-sdk/golem-js";
 
 // Collect the whitelist
 const verifiedProviders = await MarketHelpers.getHealthyProvidersWhiteList();
 
 // Prepare the whitelist filter
-const whiteList = ProposalFilters.whiteListProposalIdsFilter(verifiedProviders);
+const whiteList = ProposalFilterFactory.allowProvidersById(verifiedProviders);
+
+// Prepare the price filter
+const acceptablePrice = ProposalFilterFactory.limitPriceFilter({
+  start: 1,
+  cpuPerSec: 1 / 3600,
+  envPerSec: 1 / 3600,
+});
 
 const executor = await TaskExecutor.create({
   // What do you want to run
@@ -203,7 +203,7 @@ const executor = await TaskExecutor.create({
 
   // How much you wish to spend
   budget: 0.5,
-  proposalFilter: async (proposal) => (await acceptablePrice(proposal)) && (await whiteList(proposal)),
+  proposalFilter: (proposal) => acceptablePrice(proposal) && whiteList(proposal),
 
   // Where you want to spend
   payment: {

--- a/examples/docs-examples/examples/selecting-providers/whitelist.mjs
+++ b/examples/docs-examples/examples/selecting-providers/whitelist.mjs
@@ -1,7 +1,7 @@
-import { TaskExecutor, ProposalFilters } from "@golem-sdk/golem-js";
+import { TaskExecutor, ProposalFilterFactory } from "@golem-sdk/golem-js";
 
 /**
- * Example demonstrating how to use the predefined filter `whiteListProposalNamesFilter`,
+ * Example demonstrating how to use the predefined filter `allowProvidersByName`,
  * which only allows offers from a provider whose name is in the array
  */
 
@@ -14,7 +14,7 @@ for (let i = 0; i < whiteListNames.length; i++) {
 (async function main() {
   const executor = await TaskExecutor.create({
     package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-    proposalFilter: ProposalFilters.whiteListProposalNamesFilter(whiteListNames),
+    proposalFilter: ProposalFilterFactory.allowProvidersByName(whiteListNames),
     yagnaOptions: { apiKey: "try_golem" },
   });
 

--- a/examples/strategy/blackListProvidersIds.ts
+++ b/examples/strategy/blackListProvidersIds.ts
@@ -1,7 +1,7 @@
-import { TaskExecutor, ProposalFilters } from "@golem-sdk/golem-js";
+import { TaskExecutor, ProposalFilterFactory } from "@golem-sdk/golem-js";
 
 /**
- * Example demonstrating how to use the predefined filter `blackListProposalIdsFilter`,
+ * Example demonstrating how to use the predefined filter `disallowProvidersById`,
  * which blocking any proposal coming from a provider whose id is in the array
  */
 
@@ -14,7 +14,7 @@ const blackListProvidersIds = [
 (async function main() {
   const executor = await TaskExecutor.create({
     package: "golem/alpine:latest",
-    proposalFilter: ProposalFilters.blackListProposalIdsFilter(blackListProvidersIds),
+    proposalFilter: ProposalFilterFactory.disallowProvidersById(blackListProvidersIds),
   });
 
   try {

--- a/examples/strategy/blackListProvidersNames.ts
+++ b/examples/strategy/blackListProvidersNames.ts
@@ -1,7 +1,7 @@
-import { TaskExecutor, ProposalFilters } from "@golem-sdk/golem-js";
+import { TaskExecutor, ProposalFilterFactory } from "@golem-sdk/golem-js";
 
 /**
- * Example demonstrating how to use the predefined filter `blackListProposalNamesFilter`,
+ * Example demonstrating how to use the predefined filter `disallowProvidersByName`,
  * which blocking any proposal coming from a provider whose name is in the array
  */
 
@@ -10,7 +10,7 @@ const blackListProvidersNames = ["provider-1", "golem-provider", "super-provider
 (async function main() {
   const executor = await TaskExecutor.create({
     package: "golem/alpine:latest",
-    proposalFilter: ProposalFilters.blackListProposalNamesFilter(blackListProvidersNames),
+    proposalFilter: ProposalFilterFactory.disallowProvidersByName(blackListProvidersNames),
   });
 
   try {

--- a/examples/strategy/blackListProvidersRegexp.ts
+++ b/examples/strategy/blackListProvidersRegexp.ts
@@ -1,14 +1,14 @@
-import { TaskExecutor, ProposalFilters } from "@golem-sdk/golem-js";
+import { TaskExecutor, ProposalFilterFactory } from "@golem-sdk/golem-js";
 
 /**
- * Example demonstrating how to use the predefined selector `blackListProposalRegexpFilter`,
+ * Example demonstrating how to use the predefined selector `disallowProvidersByNameRegex`,
  * which blocking any proposal coming from a provider whose name match to the regexp
  */
 
 (async function main() {
   const executor = await TaskExecutor.create({
     package: "golem/alpine:latest",
-    proposalFilter: ProposalFilters.blackListProposalRegexpFilter(/bad-provider*./),
+    proposalFilter: ProposalFilterFactory.disallowProvidersByNameRegex(/bad-provider*./),
   });
 
   try {

--- a/examples/strategy/customProviderFilter.ts
+++ b/examples/strategy/customProviderFilter.ts
@@ -4,7 +4,7 @@ import { ProposalFilter, TaskExecutor } from "@golem-sdk/golem-js";
  * Example demonstrating how to write a custom proposal filter.
  * In this case the proposal must include VPN access and must not be from "bad-provider"
  */
-const myFilter: ProposalFilter = async (proposal) => {
+const myFilter: ProposalFilter = (proposal) => {
   return (
     proposal.provider.name !== "bad-provider" || !proposal.properties["golem.runtime.capabilities"]?.includes("vpn")
   );

--- a/examples/strategy/dynamicProposalFilter.ts
+++ b/examples/strategy/dynamicProposalFilter.ts
@@ -1,0 +1,48 @@
+/**
+ * Example demonstrating how to write a custom dynamic proposal filter.
+ *
+ * By dynamic, we understand that the filter behaviour might change over time  due to some conditions
+ */
+
+import { ProposalFilter, ProposalFilterFactory, TaskExecutor } from "@golem-sdk/golem-js";
+
+const makeDynamicFilter: () => {
+  filter: ProposalFilter;
+  stopPolling: () => void;
+} = () => {
+  let partnerProviderIds = [];
+
+  const loadPartners = () =>
+    fetch("https://provider-health.golem.network/v1/provider-whitelist")
+      .then((res) => res.json())
+      .then((list) => (partnerProviderIds = list))
+      .catch((err) => console.error("Issue when loading list of partners", err));
+
+  // Update your list of partners each 10s
+  const interval = setInterval(loadPartners, 10_000);
+
+  // Fire the load immediately
+  void loadPartners();
+
+  // Return the filter that will be called synchronously
+  return {
+    filter: ProposalFilterFactory.allowProvidersById(partnerProviderIds),
+    stopPolling: () => clearInterval(interval),
+  };
+};
+
+(async function main() {
+  const { filter, stopPolling } = makeDynamicFilter();
+  const executor = await TaskExecutor.create({
+    package: "golem/alpine:latest",
+    proposalFilter: filter,
+  });
+  try {
+    await executor.run(async (ctx) => console.log((await ctx.run("echo 'Hello World'")).stdout));
+  } catch (err) {
+    console.error("Task execution failed:", err);
+  } finally {
+    await executor.shutdown();
+    stopPolling();
+  }
+})();

--- a/examples/strategy/whiteListProvidersIds.ts
+++ b/examples/strategy/whiteListProvidersIds.ts
@@ -1,7 +1,7 @@
-import { TaskExecutor, ProposalFilters } from "@golem-sdk/golem-js";
+import { TaskExecutor, ProposalFilterFactory } from "@golem-sdk/golem-js";
 
 /**
- * Example demonstrating how to use the predefined filter `whiteListProposalIdsFilter`,
+ * Example demonstrating how to use the predefined filter `allowProvidersById`,
  * which only allows offers from a provider whose id is in the array
  */
 
@@ -14,7 +14,7 @@ const whiteListIds = [
 (async function main() {
   const executor = await TaskExecutor.create({
     package: "golem/alpine:latest",
-    proposalFilter: ProposalFilters.whiteListProposalIdsFilter(whiteListIds),
+    proposalFilter: ProposalFilterFactory.allowProvidersById(whiteListIds),
   });
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export {
 } from "./storage";
 export { ActivityStateEnum, Result, ResultState, Activity, ActivityOptions, ActivityPoolService } from "./activity";
 export { AgreementCandidate, AgreementSelectors, AgreementPoolService, AgreementServiceOptions } from "./agreement";
-export { ProposalFilters, ProposalFilter, MarketHelpers, MarketService, MarketOptions } from "./market";
+export { ProposalFilterFactory, ProposalFilter, MarketHelpers, MarketService, MarketOptions } from "./market";
 export { Package, PackageOptions, AllPackageOptions } from "./package";
 export { PaymentFilters, PaymentService, PaymentOptions } from "./payment";
 export { NetworkService, NetworkServiceOptions } from "./network";

--- a/src/market/config.ts
+++ b/src/market/config.ts
@@ -2,7 +2,7 @@ import { DemandOptions } from "./demand";
 import { EnvUtils, Logger, defaultLogger } from "../utils";
 import { MarketOptions, ProposalFilter } from "./service";
 import { YagnaOptions } from "../executor";
-import { acceptAllProposalFilter } from "./strategy";
+import { acceptAll } from "./strategy";
 import { GolemError } from "../error/golem-error";
 
 const DEFAULTS = {
@@ -13,7 +13,7 @@ const DEFAULTS = {
   debitNotesAcceptanceTimeoutSec: 2 * 60, // 2 minutes
   midAgreementDebitNoteIntervalSec: 2 * 60, // 2 minutes
   midAgreementPaymentTimeoutSec: 12 * 60 * 60, // 12 hours
-  proposalFilter: acceptAllProposalFilter(),
+  proposalFilter: acceptAll(),
 };
 
 /**

--- a/src/market/index.ts
+++ b/src/market/index.ts
@@ -3,5 +3,5 @@ export { Demand, DEMAND_EVENT_TYPE, DemandOptions, DemandEvent } from "./demand"
 export { Proposal, ProposalDetails } from "./proposal";
 export { MarketDecoration } from "./builder";
 export { DemandConfig } from "./config";
-export * as ProposalFilters from "./strategy";
+export * as ProposalFilterFactory from "./strategy";
 export * as MarketHelpers from "./helpers";

--- a/src/market/service.ts
+++ b/src/market/service.ts
@@ -8,7 +8,7 @@ import { MarketConfig } from "./config";
 import { GolemError } from "../error/golem-error";
 import { ProposalsBatch } from "./proposals_batch";
 
-export type ProposalFilter = (proposal: Proposal) => Promise<boolean> | boolean;
+export type ProposalFilter = (proposal: Proposal) => boolean;
 
 export interface MarketOptions extends DemandOptions {
   /**

--- a/src/market/strategy.ts
+++ b/src/market/strategy.ts
@@ -1,30 +1,30 @@
 import { Proposal } from "./proposal";
 
 /** Default Proposal filter that accept all proposal coming from the market */
-export const acceptAllProposalFilter = () => async () => true;
+export const acceptAll = () => () => true;
 
 /** Proposal filter blocking every offer coming from a provider whose id is in the array */
-export const blackListProposalIdsFilter = (blackListIds: string[]) => async (proposal: Proposal) =>
-  !blackListIds.includes(proposal.issuerId);
+export const disallowProvidersById = (providerIds: string[]) => (proposal: Proposal) =>
+  !providerIds.includes(proposal.provider.id);
 
 /** Proposal filter blocking every offer coming from a provider whose name is in the array */
-export const blackListProposalNamesFilter = (blackListNames: string[]) => async (proposal: Proposal) =>
-  !blackListNames.includes(proposal.provider.name);
+export const disallowProvidersByName = (providerNames: string[]) => (proposal: Proposal) =>
+  !providerNames.includes(proposal.provider.name);
 
 /** Proposal filter blocking every offer coming from a provider whose name match to the regexp */
-export const blackListProposalRegexpFilter = (regexp: RegExp) => async (proposal: Proposal) =>
+export const disallowProvidersByNameRegex = (regexp: RegExp) => (proposal: Proposal) =>
   !proposal.provider.name.match(regexp);
 
 /** Proposal filter that only allows offers from a provider whose id is in the array */
-export const whiteListProposalIdsFilter = (whiteListIds: string[]) => async (proposal: Proposal) =>
-  whiteListIds.includes(proposal.issuerId);
+export const allowProvidersById = (providerIds: string[]) => (proposal: Proposal) =>
+  providerIds.includes(proposal.provider.id);
 
 /** Proposal filter that only allows offers from a provider whose name is in the array */
-export const whiteListProposalNamesFilter = (whiteListNames: string[]) => async (proposal: Proposal) =>
-  whiteListNames.includes(proposal.provider.name);
+export const allowProvidersByName = (providerNames: string[]) => (proposal: Proposal) =>
+  providerNames.includes(proposal.provider.name);
 
 /** Proposal filter that only allows offers from a provider whose name match to the regexp */
-export const whiteListProposalRegexpFilter = (regexp: RegExp) => async (proposal: Proposal) =>
+export const allowProvidersByNameRegex = (regexp: RegExp) => (proposal: Proposal) =>
   !!proposal.provider.name.match(regexp);
 
 export type PriceLimits = {
@@ -40,7 +40,7 @@ export type PriceLimits = {
  * @param priceLimits.cpuPerSec The maximum price for CPU usage in GLM/s
  * @param priceLimits.envPerSec The maximum price for the duration of the activity in GLM/s
  */
-export const limitPriceFilter = (priceLimits: PriceLimits) => async (proposal: Proposal) => {
+export const limitPriceFilter = (priceLimits: PriceLimits) => (proposal: Proposal) => {
   return (
     proposal.pricing.cpuSec <= priceLimits.cpuPerSec &&
     proposal.pricing.envSec <= priceLimits.envPerSec &&

--- a/tests/e2e/strategies.spec.ts
+++ b/tests/e2e/strategies.spec.ts
@@ -1,4 +1,4 @@
-import { TaskExecutor, ProposalFilters } from "../../src";
+import { TaskExecutor, ProposalFilterFactory } from "../../src";
 import { LoggerMock } from "../mock";
 
 const logger = new LoggerMock(false);
@@ -11,7 +11,7 @@ describe("Strategies", function () {
     it("should filtered providers by black list names", async () => {
       const executor = await TaskExecutor.create({
         package: "golem/alpine:latest",
-        proposalFilter: ProposalFilters.blackListProposalRegexpFilter(/provider-2/),
+        proposalFilter: ProposalFilterFactory.disallowProvidersByNameRegex(/provider-2/),
         logger,
       });
       const data = ["one", "two", "three"];
@@ -33,7 +33,7 @@ describe("Strategies", function () {
     it("should filtered providers by white list names", async () => {
       const executor = await TaskExecutor.create({
         package: "golem/alpine:latest",
-        proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/provider-2/),
+        proposalFilter: ProposalFilterFactory.allowProvidersByNameRegex(/provider-2/),
         logger,
       });
       const data = ["one", "two", "three"];

--- a/tests/e2e/strategies.spec.ts
+++ b/tests/e2e/strategies.spec.ts
@@ -1,4 +1,4 @@
-import { TaskExecutor, ProposalFilterFactory } from "../../src";
+import { ProposalFilterFactory, TaskExecutor } from "../../src";
 import { LoggerMock } from "../mock";
 
 const logger = new LoggerMock(false);

--- a/tests/unit/jest.config.json
+++ b/tests/unit/jest.config.json
@@ -4,6 +4,7 @@
   "roots": ["../../src", "./"],
   "testMatch": ["**/*.test.ts", "**/*.spec.ts"],
   "reporters": [
+    "default",
     [
       "jest-junit",
       {

--- a/tests/unit/market_service.test.ts
+++ b/tests/unit/market_service.test.ts
@@ -1,5 +1,5 @@
 import { setExpectedProposals } from "../mock/rest/market";
-import { MarketService, ProposalFilters } from "../../src/market";
+import { MarketService, ProposalFilterFactory } from "../../src/market";
 import { agreementPoolServiceMock, packageMock, LoggerMock, allocationMock, YagnaMock } from "../mock";
 import {
   proposalsInitial,
@@ -89,7 +89,7 @@ describe("Market Service", () => {
     await marketService.end();
   });
   it("should reject when proposal rejected by Proposal Filter", async () => {
-    const proposalAlwaysBanFilter = () => Promise.resolve(false);
+    const proposalAlwaysBanFilter = () => false;
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
       proposalFilter: proposalAlwaysBanFilter,
@@ -104,7 +104,7 @@ describe("Market Service", () => {
   it("should reject when proposal rejected by BlackListIds Proposal Filter", async () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
-      proposalFilter: ProposalFilters.blackListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
+      proposalFilter: ProposalFilterFactory.disallowProvidersById(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
       minProposalsBatchSize: 1,
       proposalsBatchReleaseTimeoutMs: 10,
     });
@@ -116,7 +116,7 @@ describe("Market Service", () => {
   it("should reject when proposal rejected by BlackListNames Proposal Filter", async () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
-      proposalFilter: ProposalFilters.blackListProposalRegexpFilter(/golem2004/),
+      proposalFilter: ProposalFilterFactory.disallowProvidersByNameRegex(/golem2004/),
       minProposalsBatchSize: 1,
       proposalsBatchReleaseTimeoutMs: 10,
     });
@@ -128,7 +128,7 @@ describe("Market Service", () => {
   it("should reject when proposal rejected by WhiteListIds Proposal Filter", async () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
-      proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0x123455"]),
+      proposalFilter: ProposalFilterFactory.allowProvidersById(["0x123455"]),
       minProposalsBatchSize: 1,
       proposalsBatchReleaseTimeoutMs: 10,
     });
@@ -140,7 +140,7 @@ describe("Market Service", () => {
   it("should reject when proposal rejected by WhiteListNames Proposal Filter", async () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
-      proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/abcdefg/),
+      proposalFilter: ProposalFilterFactory.allowProvidersByNameRegex(/abcdefg/),
       minProposalsBatchSize: 1,
       proposalsBatchReleaseTimeoutMs: 10,
     });
@@ -152,7 +152,7 @@ describe("Market Service", () => {
   it("should respond when provider id is whitelisted by WhiteListIds Proposal Filter", async () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
-      proposalFilter: ProposalFilters.whiteListProposalIdsFilter(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
+      proposalFilter: ProposalFilterFactory.allowProvidersById(["0xee8993fe1dcff6b131d3fd759c6b3ddcb82d1655"]),
       minProposalsBatchSize: 1,
       proposalsBatchReleaseTimeoutMs: 10,
     });
@@ -164,7 +164,7 @@ describe("Market Service", () => {
   it("should respond when provider name is whitelisted by WhiteListNames Proposal Filter", async () => {
     const marketService = new MarketService(agreementPoolServiceMock, yagnaApi, {
       logger,
-      proposalFilter: ProposalFilters.whiteListProposalRegexpFilter(/golem2004/),
+      proposalFilter: ProposalFilterFactory.allowProvidersByNameRegex(/golem2004/),
       minProposalsBatchSize: 1,
       proposalsBatchReleaseTimeoutMs: 10,
     });


### PR DESCRIPTION
…enamed to be more accurate

This change embodies feedback collected from users of the SDK in regards to the confusing namnig and expectations from proposal filters. The change fixes the naming to better reflect what the filter is doing. At the same time, we don't expect the filters to be asynchronous anymore to not encourage bad pracices like having a lot of side effects (network calls etc) when just deciding whether the proposal is accepted for negotiations. Here a simple boolean check should be sufficient.

BREAKING CHANGE: ProposalFilters renamed to
ProposalFilterFactory.
acceptAllProposalFilter renamed to acceptAll and
no longer async.
blackListProposalIdsFilter renamed to
disallowProvidersById and no longer async.
blackListProposalNamesFilter
renamed disallowProvidersByName and no longer
async.
blackListProposalRegexpFilter renamed to
disallowProvidersByNameRegex and no longer
async.
whiteListProposalIdsFilter renamed to allowProvidersById and no longer async.
whiteListProposalNamesFilter renamed to
allowProvidersByName and no longer async.
whiteListProposalRegexpFilter
renamed to allowProvidersByNameRegex and no longer async.