### PR TITLE
fix(work): take provider information from agreement, and not form opt…

### DIFF
--- a/src/job/job.test.ts
+++ b/src/job/job.test.ts
@@ -32,6 +32,7 @@ describe("Job", () => {
       } as Agreement;
       const mockActivity = {
         stop: jest.fn(),
+        agreement: mockAgreement,
       } as unknown as Activity;
 
       jest.spyOn(AgreementPoolService.prototype, "getAgreement").mockResolvedValue(mockAgreement);

--- a/src/job/job.ts
+++ b/src/job/job.ts
@@ -2,10 +2,9 @@ import { TaskState as JobState } from "../task/task";
 import { WorkContext, Worker, WorkOptions } from "../task/work";
 import { runtimeContextChecker, YagnaApi } from "../utils";
 import { AgreementOptions, AgreementPoolService } from "../agreement";
-import { MarketService } from "../market";
+import { MarketOptions, MarketService } from "../market";
 import { NetworkService } from "../network";
 import { PaymentOptions, PaymentService } from "../payment";
-import { MarketOptions } from "../market";
 import { NetworkOptions } from "../network/network";
 import { Package, PackageOptions } from "../package";
 import { Activity, ActivityOptions } from "../activity";
@@ -193,7 +192,6 @@ export class Job<Output = unknown> {
       this.defaultOptions.work?.storageProvider || options.work?.storageProvider || this.getDefaultStorageProvider();
 
     const workContext = new WorkContext(activity, {
-      provider: agreement.provider,
       storageProvider,
       networkNode: await networkService.addNode(agreement.provider.id),
       activityPreparingTimeout:

--- a/src/task/service.ts
+++ b/src/task/service.ts
@@ -105,7 +105,6 @@ export class TaskService {
 
       const ctx = new WorkContext(activity, {
         activityReadySetupFunctions: this.activitySetupDone.has(activity.id) ? [] : activityReadySetupFunctions,
-        provider: agreement.provider,
         storageProvider: this.options.storageProvider,
         networkNode,
         logger: this.logger,

--- a/src/task/work.spec.ts
+++ b/src/task/work.spec.ts
@@ -193,7 +193,7 @@ describe("Work Context", () => {
         expect(result.stdout).toEqual("FAILURE");
         await logger.expectToInclude("Task error", {
           error: "Error: undefined. Stdout: FAILURE. Stderr: undefined",
-          provider: undefined,
+          provider: "Test Provider",
         });
       });
     });

--- a/src/task/work.ts
+++ b/src/task/work.ts
@@ -18,6 +18,7 @@ import { Batch } from "./batch";
 import { NetworkNode } from "../network";
 import { RemoteProcess } from "./process";
 import { GolemError } from "../error/golem-error";
+import { ProviderInfo } from "../agreement";
 
 export type Worker<OutputType> = (ctx: WorkContext) => Promise<OutputType>;
 
@@ -29,7 +30,6 @@ const DEFAULTS = {
 export interface WorkOptions {
   activityPreparingTimeout?: number;
   activityStateCheckingInterval?: number;
-  provider?: { name: string; id: string; networkConfig?: object };
   storageProvider?: StorageProvider;
   networkNode?: NetworkNode;
   logger?: Logger;
@@ -48,7 +48,7 @@ export interface CommandOptions {
  * @description
  */
 export class WorkContext {
-  public readonly provider?: { name: string; id: string; networkConfig?: object };
+  public readonly provider?: ProviderInfo;
   private readonly activityPreparingTimeout: number;
   private readonly logger: Logger;
   private readonly activityStateCheckingInterval: number;
@@ -62,7 +62,7 @@ export class WorkContext {
     this.activityPreparingTimeout = options?.activityPreparingTimeout || DEFAULTS.activityPreparingTimeout;
     this.logger = options?.logger ?? defaultLogger("work");
     this.activityStateCheckingInterval = options?.activityStateCheckingInterval || DEFAULTS.activityStateCheckInterval;
-    this.provider = options?.provider;
+    this.provider = activity.agreement.provider;
     this.storageProvider = options?.storageProvider ?? new NullStorageProvider();
     this.networkNode = options?.networkNode;
   }

--- a/src/task/work.ts
+++ b/src/task/work.ts
@@ -48,7 +48,7 @@ export interface CommandOptions {
  * @description
  */
 export class WorkContext {
-  public readonly provider?: ProviderInfo;
+  public readonly provider: ProviderInfo;
   private readonly activityPreparingTimeout: number;
   private readonly logger: Logger;
   private readonly activityStateCheckingInterval: number;
@@ -101,7 +101,7 @@ export class WorkContext {
     state = await this.activity.getState().catch((e) =>
       this.logger.warn("Error while getting activity state", {
         error: e,
-        provider: this.provider?.name,
+        provider: this.provider.name,
       }),
     );
 
@@ -141,7 +141,7 @@ export class WorkContext {
 
     this.logger.debug("Running command", {
       command: isArray ? `${exeOrCmd} ${argsOrOptions?.join(" ")}` : exeOrCmd,
-      provider: this.provider?.name,
+      provider: this.provider.name,
     });
 
     const run = isArray
@@ -311,7 +311,7 @@ export class WorkContext {
         )
         .join(". ");
       this.logger.warn(`Task error`, {
-        provider: this.provider?.name,
+        provider: this.provider.name,
         error: errorMessage,
       });
     }


### PR DESCRIPTION
…ions

BREAKING CHANGE: Low level change: `WorkOptions` no longer supports the `provider` option, as it's going to be taken from the agreement