### PR TITLE
fix(network): fixed adding an existing node to the network

### DIFF
--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -49,7 +49,6 @@ export class Network {
   private gateway?: IPv4;
   private nodes = new Map<string, NetworkNode>();
   private logger: Logger;
-  private releasedIpAddresses: Array<AbstractIPNum> = [];
 
   /**
    * Create a new VPN.
@@ -153,7 +152,6 @@ export class Network {
     try {
       await this.yagnaApi.net.removeNode(this.id, nodeId);
       this.nodes.delete(nodeId);
-      this.releasedIpAddresses.push(node.ip);
       this.logger.debug(`Node has removed from the network.`, { id: nodeId, ip: node.ip.toString() });
     } catch (error) {
       throw new GolemError(`Unable to remove node ${nodeId}. ${error}`);
@@ -183,7 +181,7 @@ export class Network {
   }
 
   private nextAddress(): IPv4 {
-    const ip = this.ipIterator.next().value || this.releasedIpAddresses.pop();
+    const ip = this.ipIterator.next().value;
     if (!ip) throw new GolemError(`No more addresses available in ${this.ipRange.toCidrString()}`);
     return ip;
   }

--- a/src/network/service.ts
+++ b/src/network/service.ts
@@ -36,6 +36,16 @@ export class NetworkService {
     return this.network.addNode(nodeId, ip);
   }
 
+  public async removeNode(nodeId: string): Promise<void> {
+    if (!this.network) throw new GolemError("The service is not started and the network does not exist");
+    return this.network.removeNode(nodeId);
+  }
+
+  public hasNode(nodeId: string) {
+    if (!this.network) throw new GolemError("The service is not started and the network does not exist");
+    return this.network.hasNode(nodeId);
+  }
+
   async end() {
     await this.network?.remove();
     this.logger.info("Network Service has been stopped");

--- a/src/task/service.ts
+++ b/src/task/service.ts
@@ -4,7 +4,7 @@ import { defaultLogger, Logger, sleep, YagnaApi } from "../utils";
 import { StorageProvider } from "../storage";
 import { Agreement, AgreementPoolService } from "../agreement";
 import { PaymentService } from "../payment";
-import { NetworkService } from "../network";
+import { NetworkNode, NetworkService } from "../network";
 import { Activity, ActivityOptions } from "../activity";
 import { TaskConfig } from "./config";
 import { Events } from "../events";
@@ -84,6 +84,7 @@ export class TaskService {
 
     const agreement = await this.agreementPoolService.getAgreement();
     let activity: Activity | undefined;
+    let networkNode: NetworkNode | undefined;
 
     try {
       activity = await this.getOrCreateActivity(agreement);
@@ -101,7 +102,9 @@ export class TaskService {
 
       const activityReadySetupFunctions = task.getActivityReadySetupFunctions();
       const worker = task.getWorker();
-      const networkNode = await this.networkService?.addNode(agreement.provider.id);
+      if (this.networkService && !this.networkService.hasNode(agreement.provider.id)) {
+        networkNode = await this.networkService.addNode(agreement.provider.id);
+      }
 
       const ctx = new WorkContext(activity, {
         activityReadySetupFunctions: this.activitySetupDone.has(activity.id) ? [] : activityReadySetupFunctions,
@@ -165,6 +168,9 @@ export class TaskService {
 
       if (activity) {
         await this.stopActivity(activity, agreement);
+      }
+      if (this.networkService && networkNode) {
+        await this.networkService.removeNode(networkNode.id);
       }
     } finally {
       --this.activeTasksCount;

--- a/tests/mock/rest/network.ts
+++ b/tests/mock/rest/network.ts
@@ -23,6 +23,16 @@ export class NetworkApiMock extends RequestorApi {
     if (this.error) return Promise.reject(this.error);
     return new Promise((res) => res({ data: undefined } as AxiosResponse));
   }
+
+  // @ts-ignore
+  removeNode(
+    networkId: string,
+    nodeId: string,
+    options?: AxiosRequestConfig,
+  ): Promise<import("axios").AxiosResponse<void>> {
+    return new Promise((res) => res({ data: undefined } as AxiosResponse));
+  }
+
   // @ts-ignore
   addAddress(
     networkId: string,

--- a/tests/mock/services/network.ts
+++ b/tests/mock/services/network.ts
@@ -6,6 +6,12 @@ export const networkServiceMock: NetworkService = {
   async addNode(nodeId: string, ip?: string): Promise<NetworkNode> {
     return Promise.resolve({} as NetworkNode);
   },
+  async removeNode(nodeId: string): Promise<void> {
+    return Promise.resolve(undefined);
+  },
+  hasNode(nodeId: string): boolean {
+    return true;
+  },
   async end(): Promise<void> {
     return Promise.resolve(undefined);
   },

--- a/tests/unit/network.test.ts
+++ b/tests/unit/network.test.ts
@@ -99,7 +99,7 @@ describe("Network", () => {
       await expect(network.addNode("4")).rejects.toThrow("No more addresses available in 192.168.0.0/30");
     });
 
-    it("should not add a node to a previously assigned address", async () => {
+    it("should throw an error when there are no free IPs available", async () => {
       const network = await Network.create(yagnaApi, { networkOwnerId: "1", networkIp: "192.168.0.0/30" });
       await network.addNode("2");
       await network.addNode("3");

--- a/tests/unit/network.test.ts
+++ b/tests/unit/network.test.ts
@@ -99,14 +99,12 @@ describe("Network", () => {
       await expect(network.addNode("4")).rejects.toThrow("No more addresses available in 192.168.0.0/30");
     });
 
-    it("should add a node if the network was full and some node was removed", async () => {
+    it("should not add a node to a previously assigned address", async () => {
       const network = await Network.create(yagnaApi, { networkOwnerId: "1", networkIp: "192.168.0.0/30" });
-      const { id, ip } = await network.addNode("2");
+      await network.addNode("2");
       await network.addNode("3");
       await network.removeNode("2");
-      const fromReleasedAddressees = await network.addNode("4");
-      expect({ id, ip: ip.toString() }).toEqual({ id: "2", ip: "192.168.0.2" });
-      expect(fromReleasedAddressees.ip.toString()).toEqual("192.168.0.2");
+      await expect(network.addNode("4")).rejects.toThrow("No more addresses available in 192.168.0.0/30");
     });
 
     it("should return true if node belongs to the network", async () => {

--- a/tests/unit/network_service.test.ts
+++ b/tests/unit/network_service.test.ts
@@ -1,6 +1,5 @@
 import { LoggerMock, YagnaMock } from "../mock";
-import { NetworkService } from "../../src/network";
-import exp from "node:constants";
+import { NetworkService } from "../../src";
 const logger = new LoggerMock();
 const yagnaApi = new YagnaMock().getApi();
 describe("Network Service", () => {

--- a/tests/unit/network_service.test.ts
+++ b/tests/unit/network_service.test.ts
@@ -1,5 +1,6 @@
 import { LoggerMock, YagnaMock } from "../mock";
 import { NetworkService } from "../../src/network";
+import exp from "node:constants";
 const logger = new LoggerMock();
 const yagnaApi = new YagnaMock().getApi();
 describe("Network Service", () => {
@@ -26,25 +27,47 @@ describe("Network Service", () => {
   });
 
   describe("Nodes", () => {
-    it("should add node to network", async () => {
-      const networkService = new NetworkService(yagnaApi, { logger });
-      await networkService.run("test_owner_id");
-      await networkService.addNode("provider_2");
-      await logger.expectToInclude(
-        "Node has added to the network.",
-        {
-          id: "provider_2",
-          ip: "192.168.0.2",
-        },
-        10,
-      );
-      await networkService.end();
-    });
+    describe("adding", () => {
+      it("should add node to network", async () => {
+        const networkService = new NetworkService(yagnaApi, { logger });
+        await networkService.run("test_owner_id");
+        await networkService.addNode("provider_2");
+        await logger.expectToInclude(
+          "Node has added to the network.",
+          {
+            id: "provider_2",
+            ip: "192.168.0.2",
+          },
+          10,
+        );
+        await networkService.end();
+      });
 
-    it("should not add node if the service is not started", async () => {
-      const networkService = new NetworkService(yagnaApi, { logger });
-      const result = networkService.addNode("provider_2");
-      await expect(result).rejects.toThrow("The service is not started and the network does not exist");
+      it("should not add node if the service is not started", async () => {
+        const networkService = new NetworkService(yagnaApi, { logger });
+        const result = networkService.addNode("provider_2");
+        await expect(result).rejects.toThrow("The service is not started and the network does not exist");
+      });
+    });
+    describe("removing", () => {
+      it("should remove node from the network", async () => {
+        const networkService = new NetworkService(yagnaApi, { logger });
+        await networkService.run("test_owner_id");
+        await networkService.addNode("provider_2");
+        const removeNetworkApiSpy = jest.spyOn(yagnaApi.net, "removeNode");
+        await networkService.removeNode("provider_2");
+        expect(removeNetworkApiSpy).toHaveBeenCalled();
+        await networkService.end();
+      });
+      it("should not remove node from the network", async () => {
+        const networkService = new NetworkService(yagnaApi, { logger });
+        await networkService.run("test_owner_id");
+        await networkService.addNode("provider_2");
+        await expect(networkService.removeNode("provider_777")).rejects.toThrow(
+          "Unable to remove node provider_777. There is no such node in the network",
+        );
+        await networkService.end();
+      });
     });
   });
 

--- a/tests/unit/tasks_service.test.ts
+++ b/tests/unit/tasks_service.test.ts
@@ -152,7 +152,7 @@ describe("Task Service", () => {
         taskId: task.id,
         reason: "Work rejected. Reason: Invalid value computed by provider",
       },
-      2500,
+      1500,
     );
     expect(task.isFinished()).toEqual(true);
     await service.end();

--- a/tests/unit/tasks_service.test.ts
+++ b/tests/unit/tasks_service.test.ts
@@ -1,7 +1,6 @@
 import * as activityMock from "../mock/rest/activity";
 import { Task, TaskQueue, TaskService, WorkContext, Worker } from "../../src/task";
 import { agreementPoolServiceMock, paymentServiceMock, networkServiceMock, LoggerMock, YagnaMock } from "../mock";
-import { sleep } from "../../src/utils";
 
 let queue: TaskQueue;
 const logger = new LoggerMock();
@@ -153,7 +152,7 @@ describe("Task Service", () => {
         taskId: task.id,
         reason: "Work rejected. Reason: Invalid value computed by provider",
       },
-      1500,
+      2500,
     );
     expect(task.isFinished()).toEqual(true);
     await service.end();


### PR DESCRIPTION
Fixed a bug related to adding a node to the network. There was no checking whether the node existed. Additionally, added the ability to remove a node from the network and handle it in TaskService.