### PR TITLE
fix(task-executor): propagate issues with invoice and debit note filt…

### DIFF
--- a/src/executor/executor.spec.ts
+++ b/src/executor/executor.spec.ts
@@ -30,6 +30,9 @@ jest.mock("../payment/service", () => {
         createAllocation: jest.fn(),
         run: serviceRunSpy,
         end: jest.fn(),
+        events: {
+          on: jest.fn(),
+        },
       };
     }),
   };


### PR DESCRIPTION
…er to user

Right now the payment service has silently tolerated user triggered errors from the invoice or debit note filters - the buggy code was still operating producing bad market outcomes - leading to the providers terminating agreements due to not accepted debit notes. The users were left clueless.

What the PR changes is: given there's any issue with processing an invoice or debit note, then it's not only logged in the SDK on error level, but also an `error` event is raised from the `PaymentService`. This error is then listened to by the `TaskExecutor`, which cancels itself in response - producing the information to the user and stopping the buggy code to operate.

One side effect here is that
_any_ issue with the processing will lead to the shutdown of the TaskExecutor.

BREAKING CHANGE: The TaskExecutor will now be cancelled when an issue will be raised with processing the payments - including errors in the invoice and debit note filters.