### PR TITLE
fix(task): fixed retrying and timeout measurement for task

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -54,8 +54,8 @@ export class TaskStarted extends BaseEvent<{
  */
 export class TaskRedone extends BaseEvent<{
   id: string;
-  agreementId: string;
-  provider: ProviderInfo;
+  agreementId?: string;
+  provider?: ProviderInfo;
   retriesCount: number;
   /**
    * The activity that was involved
@@ -72,9 +72,9 @@ export class TaskRedone extends BaseEvent<{
  */
 export class TaskRejected extends BaseEvent<{
   id: string;
-  agreementId: string;
+  agreementId?: string;
 
-  provider: ProviderInfo;
+  provider?: ProviderInfo;
   /**
    * The activity that was involved when the rejection took place
    *

--- a/src/executor/config.ts
+++ b/src/executor/config.ts
@@ -32,7 +32,6 @@ export class ExecutorConfig {
   readonly logger: Logger;
   readonly eventTarget: EventTarget;
   readonly maxTaskRetries: number;
-  readonly activityExecuteTimeout?: number;
   readonly startupTimeout: number;
   readonly exitOnNoProposals: boolean;
 
@@ -49,7 +48,6 @@ export class ExecutorConfig {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore FIXME: this weirdness may not be needed anymore?
     Object.keys(options).forEach((key) => (this[key] = options[key]));
-    this.activityExecuteTimeout = options.activityExecuteTimeout || options.taskTimeout;
     const apiKey = options?.yagnaOptions?.apiKey || processEnv.env.YAGNA_APPKEY;
     if (!apiKey) {
       throw new GolemConfigError("Api key not defined");

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -375,8 +375,9 @@ export class TaskExecutor {
   }
 
   private async executeTask<OutputType>(worker: Worker<OutputType>, options?: TaskOptions): Promise<OutputType> {
+    let task;
     try {
-      const task = new Task((++this.lastTaskIndex).toString(), worker, {
+      task = new Task((++this.lastTaskIndex).toString(), worker, {
         maxRetries: options?.maxRetries ?? this.options.maxTaskRetries,
         timeout: options?.timeout ?? this.options.taskTimeout,
         activityReadySetupFunctions: this.activityReadySetupFunctions,
@@ -397,9 +398,9 @@ export class TaskExecutor {
       throw new GolemWorkError(
         `Unable to execute task. ${error.toString()}`,
         WorkErrorCode.TaskExecutionFailed,
-        undefined,
-        undefined,
-        undefined,
+        task?.getActivity()?.agreement,
+        task?.getActivity(),
+        task?.getActivity()?.getProviderInfo(),
         error,
       );
     }

--- a/src/task/service.ts
+++ b/src/task/service.ts
@@ -201,7 +201,7 @@ export class TaskService {
       });
     } else {
       this.options.eventTarget?.dispatchEvent(new Events.TaskFinished({ id: task.id }));
-      this.logger.info(`Task has been successfully completed`, {
+      this.logger.info(`Task computed`, {
         taskId: task.id,
         retries: task.getRetriesCount(),
         providerName: task.getActivity()?.getProviderInfo().name,

--- a/src/task/service.ts
+++ b/src/task/service.ts
@@ -9,7 +9,6 @@ import { Activity, ActivityOptions } from "../activity";
 import { TaskConfig } from "./config";
 import { Events } from "../events";
 import { Task } from "./task";
-import { GolemWorkError, WorkErrorCode } from "./error";
 
 export interface TaskServiceOptions extends ActivityOptions {
   /** Number of maximum parallel running task on one TaskExecutor instance */
@@ -58,6 +57,13 @@ export class TaskService {
         await sleep(this.options.taskRunningInterval, true);
         continue;
       }
+      task.onStateChange(() => {
+        if (task.isRetry()) {
+          this.retryTask(task).catch((error) => this.logger.error(`Issue with retrying a task on Golem`, error));
+        } else if (task.isFinished()) {
+          this.stopTask(task).catch((error) => this.logger.error(`Issue with stopping a task on Golem`, error));
+        }
+      });
       this.startTask(task).catch(
         (error) => this.isRunning && this.logger.error(`Issue with starting a task on Golem`, error),
       );
@@ -78,8 +84,8 @@ export class TaskService {
   }
 
   private async startTask(task: Task) {
-    task.start();
-    this.logger.debug(`Starting task`, { taskId: task.id });
+    task.init();
+    this.logger.debug(`Starting task`, { taskId: task.id, attempt: task.getRetriesCount() + 1 });
     ++this.activeTasksCount;
 
     const agreement = await this.agreementPoolService.getAgreement();
@@ -88,7 +94,7 @@ export class TaskService {
 
     try {
       activity = await this.getOrCreateActivity(agreement);
-
+      task.start(activity, networkNode);
       this.options.eventTarget?.dispatchEvent(
         new Events.TaskStarted({
           id: task.id,
@@ -97,8 +103,11 @@ export class TaskService {
           provider: agreement.getProviderInfo(),
         }),
       );
-
-      this.logger.info(`Task sent to provider`, { taskId: task.id, providerName: agreement.getProviderInfo().name });
+      this.logger.info(`Task started`, {
+        taskId: task.id,
+        providerName: agreement.getProviderInfo().name,
+        activityId: activity.id,
+      });
 
       const activityReadySetupFunctions = task.getActivityReadySetupFunctions();
       const worker = task.getWorker();
@@ -121,74 +130,18 @@ export class TaskService {
         this.activitySetupDone.add(activity.id);
         this.logger.debug(`Activity setup completed`, { activityId: activity.id });
       }
-
       const results = await worker(ctx);
       task.stop(results);
-
-      this.options.eventTarget?.dispatchEvent(new Events.TaskFinished({ id: task.id }));
-      this.logger.info(`Task computed`, { taskId: task.id, providerName: agreement.getProviderInfo().name });
     } catch (error) {
       task.stop(undefined, error);
-
-      const reason = error.message || error.toString();
-      this.logger.warn(`Starting task failed`, { reason });
-
-      if (task.isRetry() && this.isRunning) {
-        this.tasksQueue.addToBegin(task);
-        this.options.eventTarget?.dispatchEvent(
-          new Events.TaskRedone({
-            id: task.id,
-            activityId: activity?.id,
-            agreementId: agreement.id,
-            provider: agreement.getProviderInfo(),
-            retriesCount: task.getRetriesCount(),
-            reason,
-          }),
-        );
-        this.logger.warn(`Task execution failed. Trying to redo the task.`, {
-          taskId: task.id,
-          attempt: task.getRetriesCount(),
-          reason,
-        });
-      } else {
-        this.options.eventTarget?.dispatchEvent(
-          new Events.TaskRejected({
-            id: task.id,
-            agreementId: agreement.id,
-            activityId: activity?.id,
-            provider: agreement.getProviderInfo(),
-            reason,
-          }),
-        );
-        task.cleanup();
-        this.logger.error(`Task has been rejected`, { taskId: task.id, reason });
-        throw new GolemWorkError(
-          `Task ${task.id} has been rejected! ${reason}`,
-          WorkErrorCode.TaskRejected,
-          agreement,
-          activity,
-          agreement.getProviderInfo(),
-          error,
-        );
-      }
-
-      if (activity) {
-        await this.stopActivity(activity, agreement);
-      }
-      if (this.networkService && networkNode) {
-        await this.networkService.removeNode(networkNode.id);
-      }
     } finally {
       --this.activeTasksCount;
-      await this.agreementPoolService
-        .releaseAgreement(agreement.id, task.isDone())
-        .catch((error) => this.logger.error(`Releasing agreement failed`, { agreementId: agreement.id, error }));
     }
   }
 
-  private async stopActivity(activity: Activity, agreement: Agreement) {
-    await activity?.stop();
-    this.activities.delete(agreement.id);
+  private async stopActivity(activity: Activity) {
+    await activity.stop();
+    this.activities.delete(activity.agreement.id);
   }
 
   private async getOrCreateActivity(agreement: Agreement) {
@@ -200,6 +153,88 @@ export class TaskService {
       this.activities.set(agreement.id, activity);
       this.paymentService.acceptPayments(agreement);
       return activity;
+    }
+  }
+
+  private async retryTask(task: Task) {
+    if (!this.isRunning) return;
+    task.cleanup();
+    await this.releaseTaskResources(task);
+    const reason = task.getError()?.message;
+    this.options.eventTarget?.dispatchEvent(
+      new Events.TaskRedone({
+        id: task.id,
+        activityId: task.getActivity()?.id,
+        agreementId: task.getActivity()?.agreement.id,
+        provider: task.getActivity()?.getProviderInfo(),
+        retriesCount: task.getRetriesCount(),
+        reason,
+      }),
+    );
+    this.logger.warn(`Task execution failed. Trying to redo the task.`, {
+      taskId: task.id,
+      attempt: task.getRetriesCount(),
+      reason,
+    });
+    this.tasksQueue.addToBegin(task);
+  }
+
+  private async stopTask(task: Task) {
+    task.cleanup();
+    await this.releaseTaskResources(task);
+    if (task.isRejected()) {
+      const reason = task.getError()?.message;
+      this.options.eventTarget?.dispatchEvent(
+        new Events.TaskRejected({
+          id: task.id,
+          agreementId: task.getActivity()?.agreement.id,
+          activityId: task.getActivity()?.id,
+          provider: task.getActivity()?.getProviderInfo(),
+          reason,
+        }),
+      );
+      this.logger.error(`Task has been rejected`, {
+        taskId: task.id,
+        reason: task.getError()?.message,
+        retries: task.getRetriesCount(),
+        providerName: task.getActivity()?.getProviderInfo().name,
+      });
+    } else {
+      this.options.eventTarget?.dispatchEvent(new Events.TaskFinished({ id: task.id }));
+      this.logger.info(`Task has been successfully completed`, {
+        taskId: task.id,
+        retries: task.getRetriesCount(),
+        providerName: task.getActivity()?.getProviderInfo().name,
+      });
+    }
+  }
+
+  private async releaseTaskResources(task: Task) {
+    const activity = task.getActivity();
+    if (activity) {
+      if (task.isFailed()) {
+        /**
+         * Activity should only be terminated when the task fails.
+         * We assume that the next attempt should be performed on a new activity instance.
+         * For successfully completed tasks, activities remain in the ready state
+         * and are ready to be used for other tasks.
+         * For them, termination will be completed with the end of service
+         */
+        await this.stopActivity(activity).catch((error) =>
+          this.logger.error(`Stopping activity failed`, { activityId: activity.id, error }),
+        );
+      }
+      await this.agreementPoolService
+        .releaseAgreement(activity.agreement.id, task.isDone())
+        .catch((error) =>
+          this.logger.error(`Releasing agreement failed`, { agreementId: activity.agreement.id, error }),
+        );
+    }
+    const networkNode = task.getNetworkNode();
+    if (this.networkService && networkNode) {
+      await this.networkService
+        .removeNode(networkNode.id)
+        .catch((error) => this.logger.error(`Removing network node failed`, { nodeId: networkNode.id, error }));
     }
   }
 }

--- a/tests/e2e/strategies.spec.ts
+++ b/tests/e2e/strategies.spec.ts
@@ -24,9 +24,21 @@ describe("Strategies", function () {
       const finalOutputs = (await Promise.all(futureResults)).filter((x) => !!x);
       expect(finalOutputs).toEqual(expect.arrayContaining(data));
       await logger.expectToMatch(/Proposal rejected by Proposal Filter/, 5000);
-      await logger.expectToInclude(`Task computed`, { providerName: "provider-1", taskId: "1" }, 5000);
-      await logger.expectToInclude(`Task computed`, { providerName: "provider-1", taskId: "2" }, 5000);
-      await logger.expectToInclude(`Task computed`, { providerName: "provider-1", taskId: "3" }, 5000);
+      await logger.expectToInclude(
+        `Task computed`,
+        { providerName: "provider-1", taskId: "1", retries: expect.anything() },
+        5000,
+      );
+      await logger.expectToInclude(
+        `Task computed`,
+        { providerName: "provider-1", taskId: "2", retries: expect.anything() },
+        5000,
+      );
+      await logger.expectToInclude(
+        `Task computed`,
+        { providerName: "provider-1", taskId: "3", retries: expect.anything() },
+        5000,
+      );
       await executor.shutdown();
     });
 
@@ -46,9 +58,21 @@ describe("Strategies", function () {
       const finalOutputs = (await Promise.all(futureResults)).filter((x) => !!x);
       expect(finalOutputs).toEqual(expect.arrayContaining(data));
       await logger.expectToMatch(/Proposal rejected by Proposal Filter/, 5000);
-      await logger.expectToInclude(`Task computed`, { providerName: `provider-2`, taskId: "1" }, 5000);
-      await logger.expectToInclude(`Task computed`, { providerName: `provider-2`, taskId: "2" }, 5000);
-      await logger.expectToInclude(`Task computed`, { providerName: `provider-2`, taskId: "3" }, 5000);
+      await logger.expectToInclude(
+        `Task computed`,
+        { providerName: `provider-2`, taskId: "1", retries: expect.anything() },
+        5000,
+      );
+      await logger.expectToInclude(
+        `Task computed`,
+        { providerName: `provider-2`, taskId: "2", retries: expect.anything() },
+        5000,
+      );
+      await logger.expectToInclude(
+        `Task computed`,
+        { providerName: `provider-2`, taskId: "3", retries: expect.anything() },
+        5000,
+      );
       await executor.shutdown();
     });
   });

--- a/tests/e2e/tasks.spec.ts
+++ b/tests/e2e/tasks.spec.ts
@@ -98,7 +98,11 @@ describe("Task Executor", function () {
         executor.shutdown();
         expect(e).toBeUndefined();
       });
-    await logger.expectToInclude("Task computed", { taskId: "1", providerName: expect.anything() }, 5000);
+    await logger.expectToInclude(
+      "Task computed",
+      { taskId: "1", providerName: expect.anything(), retries: expect.anything() },
+      5000,
+    );
     expect(outputs[0]).toEqual("Hello Golem");
     expect(outputs[1]).toEqual("Hello World");
     expect(outputs[2]).toEqual("OK");

--- a/tests/unit/tasks_service.test.ts
+++ b/tests/unit/tasks_service.test.ts
@@ -57,9 +57,9 @@ describe("Task Service", () => {
       },
     );
     service.run().catch((e) => console.error(e));
-    expect(task1.isPending()).toEqual(true);
-    expect(task2.isPending()).toEqual(true);
-    expect(task3.isPending()).toEqual(false);
+    expect(task1.isQueued()).toEqual(true);
+    expect(task2.isQueued()).toEqual(true);
+    expect(task3.isQueued()).toEqual(false);
     expect(task3.isNew()).toEqual(true);
     await service.end();
   });
@@ -113,7 +113,11 @@ describe("Task Service", () => {
     );
     service.run().catch((e) => console.error(e));
     await logger.expectToNotMatch(/Trying to redo the task/, 100);
-    await logger.expectToInclude("Task has been rejected", { taskId: task.id, reason: expect.anything() }, 100);
+    await logger.expectToInclude(
+      "Task has been rejected",
+      { taskId: task.id, reason: expect.anything(), retries: 0, providerName: expect.anything() },
+      100,
+    );
     await service.end();
   });
 
@@ -147,6 +151,8 @@ describe("Task Service", () => {
       {
         taskId: task.id,
         reason: expect.anything(),
+        retries: 1,
+        providerName: expect.anything(),
       },
       1800,
     );


### PR DESCRIPTION
Now the task timeout is measured for each attempt separately.
Additionally, I refactored the task service by separating individual blocks into startTask, retryTask and stopTask. They are triggered by a change in the task state.
I added another state for the task - `queued`. Now, when we start the task, the task changes its state from new -> queued and when agreement and activity are created, the task starts (state pending) and from that moment the timeout is counted. It seems that this approach is better, because now the duration of the task is counted from the moment of running the first activity command (deploy) and this does not include negotiations with the market.