### PR TITLE
fix(agreement_pool): added agreement pool size limit

### DIFF
--- a/src/agreement/config.ts
+++ b/src/agreement/config.ts
@@ -9,6 +9,7 @@ const DEFAULTS = {
   agreementSelector: randomAgreementSelectorWithPriorityForExistingOnes(),
   agreementMaxEvents: 100,
   agreementEventsFetchingIntervalSec: 5,
+  agreementMaxPoolSize: 5,
 };
 
 /**
@@ -35,12 +36,14 @@ export class AgreementConfig {
 export class AgreementServiceConfig extends AgreementConfig {
   readonly agreementSelector: AgreementSelector;
   readonly agreementMaxEvents: number;
+  readonly agreementMaxPoolSize: number;
   readonly agreementEventsFetchingIntervalSec: number;
 
   constructor(options?: AgreementServiceOptions) {
     super(options);
     this.agreementSelector = options?.agreementSelector ?? DEFAULTS.agreementSelector;
     this.agreementMaxEvents = options?.agreementMaxEvents ?? DEFAULTS.agreementMaxEvents;
+    this.agreementMaxPoolSize = options?.agreementMaxPoolSize ?? DEFAULTS.agreementMaxPoolSize;
     this.agreementEventsFetchingIntervalSec =
       options?.agreementEventsFetchingIntervalSec ?? DEFAULTS.agreementEventsFetchingIntervalSec;
   }

--- a/src/agreement/service.ts
+++ b/src/agreement/service.ts
@@ -81,7 +81,7 @@ export class AgreementPoolService {
     const agreementsInPool = Array.from(this.pool).filter((a) => a.agreement);
     const isPoolFull = agreementsInPool.length >= this.config.agreementMaxPoolSize;
     if (allowReuse && isPoolFull) {
-      this.logger.debug(`Agreement cannot be released back into the pool because the pool is already full`, {
+      this.logger.debug(`Agreement cannot return to the pool because the pool is already full`, {
         id: agreementId,
       });
     }

--- a/src/executor/config.ts
+++ b/src/executor/config.ts
@@ -35,6 +35,7 @@ export class ExecutorConfig {
   readonly activityExecuteTimeout?: number;
   readonly startupTimeout: number;
   readonly exitOnNoProposals: boolean;
+  readonly agreementMaxPoolSize: number;
 
   constructor(options: ExecutorOptions & ActivityOptions) {
     const processEnv = !runtimeContextChecker.isBrowser
@@ -89,5 +90,6 @@ export class ExecutorConfig {
     this.maxTaskRetries = options.maxTaskRetries ?? DEFAULTS.maxTaskRetries;
     this.startupTimeout = options.startupTimeout ?? DEFAULTS.startupTimeout;
     this.exitOnNoProposals = options.exitOnNoProposals ?? DEFAULTS.exitOnNoProposals;
+    this.agreementMaxPoolSize = options.agreementMaxPoolSize ?? DEFAULTS.maxParallelTasks;
   }
 }

--- a/src/executor/config.ts
+++ b/src/executor/config.ts
@@ -90,6 +90,11 @@ export class ExecutorConfig {
     this.maxTaskRetries = options.maxTaskRetries ?? DEFAULTS.maxTaskRetries;
     this.startupTimeout = options.startupTimeout ?? DEFAULTS.startupTimeout;
     this.exitOnNoProposals = options.exitOnNoProposals ?? DEFAULTS.exitOnNoProposals;
+    /**
+     * If the user does not explicitly specify the maximum size of the aggregate pool, the value of maxParallelTask will be set.
+     * This means that the pool will contain a maximum number of agreements ready for reuse equal to the maximum number of tasks executed simultaneously.
+     * This will avoid the situation of keeping unused agreements and activities and, consequently, unnecessary costs.
+     */
     this.agreementMaxPoolSize = options.agreementMaxPoolSize ?? DEFAULTS.maxParallelTasks;
   }
 }

--- a/tests/mock/rest/market.ts
+++ b/tests/mock/rest/market.ts
@@ -20,8 +20,7 @@ export class MarketApiMock extends RequestorApi {
     createAgreementRequest: AgreementProposal,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<string>> {
-    const agreementData = agreementsApproved[0];
-    return new Promise((res) => res({ data: agreementData.agreementId } as AxiosResponse));
+    return new Promise((res) => res({ data: uuidv4() } as AxiosResponse));
   }
   // @ts-ignore
   async getAgreement(agreementId: string, options?: AxiosRequestConfig): Promise<AxiosResponse<string>> {

--- a/tests/unit/agreement.test.ts
+++ b/tests/unit/agreement.test.ts
@@ -18,7 +18,7 @@ describe("Agreement", () => {
     it("should create agreement for given proposal Id", async () => {
       const agreement = await Agreement.create(proposal, yagnaApi, { logger });
       expect(agreement).toBeInstanceOf(Agreement);
-      expect(agreement.id).toHaveLength(64);
+      expect(agreement.id).toBeDefined();
       await logger.expectToInclude("Agreement created", { id: agreement.id });
     });
   });

--- a/tests/unit/agreement_pool_service.test.ts
+++ b/tests/unit/agreement_pool_service.test.ts
@@ -127,7 +127,7 @@ describe("Agreement Pool Service", () => {
       await agreementService.releaseAgreement(agreement1.id, true);
       await agreementService.releaseAgreement(agreement2.id, true);
       await logger.expectToInclude(`Agreement has been released for reuse`, { id: agreement1.id });
-      await logger.expectToInclude(`Agreement cannot be released back into the pool because the pool is already full`, {
+      await logger.expectToInclude(`Agreement cannot return to the pool because the pool is already full`, {
         id: agreement2.id,
       });
       await logger.expectToInclude(`Agreement has been released and will be terminated`, { id: agreement2.id });


### PR DESCRIPTION
Added a mechanism for checking whether the pool is full when releasing an agreement.
By default, the agreementMaxPoolSize parameter is set by TaskExecutor with a value equal to maxParallelTasks