### PR TITLE
fix(payment): renamed expires parameter to expirationSec for the Allocation

### DIFF
--- a/src/payment/allocation.ts
+++ b/src/payment/allocation.ts
@@ -14,7 +14,7 @@ export interface AllocationOptions extends BasePaymentOptions {
     address: string;
     platform: string;
   };
-  expires?: number;
+  expirationSec?: number;
 }
 
 /**
@@ -52,7 +52,7 @@ export class Allocation {
         paymentPlatform: config.account.platform,
         address: config.account.address,
         timestamp: now.toISOString(),
-        timeout: new Date(+now + config.expires).toISOString(),
+        timeout: new Date(+now + config.expirationSec * 1000).toISOString(),
         makeDeposit: false,
         remainingAmount: "",
         spentAmount: "",

--- a/src/payment/config.ts
+++ b/src/payment/config.ts
@@ -10,7 +10,7 @@ const DEFAULTS = Object.freeze({
   payment: { network: "goerli", driver: "erc20" },
   budget: 1.0,
   paymentTimeout: 1000 * 60, // 1 min
-  allocationExpires: 1000 * 60 * 60, // 60 min
+  allocationExpirationSec: 60 * 60, // 60 min
   invoiceReceiveTimeout: 1000 * 60 * 5, // 5 min
   maxInvoiceEvents: 500,
   maxDebitNotesEvents: 500,
@@ -81,7 +81,7 @@ export class PaymentConfig extends BaseConfig {
 export class AllocationConfig extends BaseConfig {
   public readonly budget: number;
   public readonly payment: { driver: string; network: string };
-  public readonly expires: number;
+  public readonly expirationSec: number;
   public readonly account: { address: string; platform: string };
 
   constructor(options?: AllocationOptions) {
@@ -95,7 +95,7 @@ export class AllocationConfig extends BaseConfig {
       driver: options?.payment?.driver || DEFAULTS.payment.driver,
       network: options?.payment?.network || DEFAULTS.payment.network,
     };
-    this.expires = options?.expires || DEFAULTS.allocationExpires;
+    this.expirationSec = options?.expirationSec || DEFAULTS.allocationExpirationSec;
   }
 }
 /**


### PR DESCRIPTION
AllocationOptions property `expires` got renamed to `expirationSec` and the value should be `seconds` instead of `milliseconds`