### PR TITLE
fix: enabling imports needed for external libraries

### DIFF
--- a/src/agreement/agreement.ts
+++ b/src/agreement/agreement.ts
@@ -1,6 +1,5 @@
-import { Logger, YagnaApi, defaultLogger } from "../utils";
+import { Logger, YagnaApi, YagnaOptions, defaultLogger } from "../utils";
 import { Agreement as AgreementModel } from "ya-ts-client/dist/ya-market/src/models";
-import { YagnaOptions } from "../executor";
 import { AgreementFactory } from "./factory";
 import { AgreementConfig } from "./config";
 import { Events } from "../events";

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -1,1 +1,1 @@
-export { TaskExecutor, YagnaOptions, ExecutorOptions, ExecutorOptionsMixin } from "./executor";
+export { TaskExecutor, ExecutorOptions, ExecutorOptionsMixin } from "./executor";

--- a/src/golem_network/golem_network.ts
+++ b/src/golem_network/golem_network.ts
@@ -1,7 +1,6 @@
 import { v4 } from "uuid";
-import { YagnaOptions } from "../executor";
 import { Job } from "../job";
-import { Yagna, YagnaApi } from "../utils";
+import { Yagna, YagnaApi, YagnaOptions } from "../utils";
 import { RunJobOptions } from "../job/job";
 import { GolemUserError } from "../error/golem-error";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,16 @@
-export { TaskExecutor, ExecutorOptions } from "./executor";
-export {
-  StorageProvider,
-  GftpStorageProvider,
-  NullStorageProvider,
-  WebSocketBrowserStorageProvider,
-  WebSocketStorageProviderOptions,
-} from "./storage";
-export {
-  ActivityStateEnum,
-  Result,
-  ResultState,
-  Activity,
-  ActivityOptions,
-  ActivityPoolService,
-  ActivityConfig,
-} from "./activity";
-export {
-  Agreement,
-  AgreementCandidate,
-  AgreementSelectors,
-  AgreementPoolService,
-  AgreementServiceOptions,
-} from "./agreement";
-export {
-  ProposalFilterFactory,
-  ProposalFilter,
-  MarketHelpers,
-  MarketService,
-  MarketOptions,
-  GolemMarketError,
-  MarketErrorCode,
-  Proposal,
-} from "./market";
-export { Package, PackageOptions, AllPackageOptions } from "./package";
-export {
-  PaymentFilters,
-  PaymentService,
-  PaymentOptions,
-  InvoiceProcessor,
-  InvoiceAcceptResult,
-  GolemPaymentError,
-  PaymentErrorCode,
-} from "./payment";
-export {
-  NetworkService,
-  Network,
-  NetworkNode,
-  NetworkServiceOptions,
-  GolemNetworkError,
-  NetworkErrorCode,
-} from "./network";
-export { Events, BaseEvent, EVENT_TYPE } from "./events";
-export { Logger, jsonLogger, nullLogger, pinoLogger, defaultLogger, runtimeContextChecker } from "./utils";
-export { Yagna, YagnaApi, YagnaOptions } from "./utils/yagna/yagna";
-export { Job, JobState } from "./job";
+export * from "./executor";
+export * from "./storage";
+export * from "./activity";
+export * from "./agreement";
+export * from "./market";
+export * from "./package";
+export * from "./payment";
+export * from "./network";
+export * from "./events";
+export * from "./utils";
+export * from "./utils/yagna/yagna";
 export * from "./golem_network";
-export { Worker, WorkContext, WorkOptions, GolemWorkError, WorkErrorCode } from "./task";
+export * from "./job";
+export * from "./task";
 export * from "./error/golem-error";
 export { StatsService } from "./stats/service";

--- a/src/market/config.ts
+++ b/src/market/config.ts
@@ -1,7 +1,6 @@
 import { DemandOptions } from "./demand";
-import { EnvUtils, Logger, defaultLogger } from "../utils";
+import { EnvUtils, Logger, defaultLogger, YagnaOptions } from "../utils";
 import { MarketOptions, ProposalFilter } from "./service";
-import { YagnaOptions } from "../executor";
 import { GolemConfigError } from "../error/golem-error";
 import { acceptAll } from "./strategy";
 

--- a/src/market/demand.ts
+++ b/src/market/demand.ts
@@ -1,9 +1,8 @@
 import { Package } from "../package";
 import { Allocation } from "../payment";
-import { YagnaOptions } from "../executor";
 import { DemandFactory } from "./factory";
 import { Proposal } from "./proposal";
-import { defaultLogger, Logger, sleep, YagnaApi } from "../utils";
+import { defaultLogger, Logger, sleep, YagnaApi, YagnaOptions } from "../utils";
 import { DemandConfig } from "./config";
 import { Events } from "../events";
 import { ProposalEvent, ProposalRejectedEvent } from "ya-ts-client/dist/ya-market/src/models";

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -1,6 +1,5 @@
 import { AbstractIPNum, IPv4, IPv4CidrRange, IPv4Mask, IPv4Prefix } from "ip-num";
-import { Logger, YagnaApi } from "../utils";
-import { YagnaOptions } from "../executor";
+import { Logger, YagnaApi, YagnaOptions } from "../utils";
 import { NetworkConfig } from "./config";
 import { NetworkNode } from "./node";
 import { GolemNetworkError, NetworkErrorCode } from "./error";

--- a/src/payment/config.ts
+++ b/src/payment/config.ts
@@ -1,6 +1,5 @@
 import { AllocationOptions } from "./allocation";
-import { EnvUtils, Logger, defaultLogger } from "../utils";
-import { YagnaOptions } from "../executor";
+import { EnvUtils, Logger, defaultLogger, YagnaOptions } from "../utils";
 import { DebitNoteFilter, InvoiceFilter, PaymentOptions } from "./service";
 import { InvoiceOptions } from "./invoice";
 import { acceptAllDebitNotesFilter, acceptAllInvoicesFilter } from "./strategy";

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -1,4 +1,4 @@
-export { PaymentService, PaymentOptions } from "./service";
+export { PaymentService, PaymentOptions, PaymentServiceEvents } from "./service";
 export { Invoice } from "./invoice";
 export { DebitNote } from "./debit_note";
 export { Allocation } from "./allocation";
@@ -7,3 +7,4 @@ export { Rejection, RejectionReason } from "./rejection";
 export * as PaymentFilters from "./strategy";
 export { GolemPaymentError, PaymentErrorCode } from "./error";
 export { InvoiceProcessor, InvoiceAcceptResult } from "./InvoiceProcessor";
+export { PaymentConfig } from "./config";

--- a/src/payment/service.ts
+++ b/src/payment/service.ts
@@ -9,7 +9,7 @@ import { AgreementPaymentProcess } from "./agreement_payment_process";
 import { GolemPaymentError, PaymentErrorCode } from "./error";
 import { EventEmitter } from "eventemitter3";
 
-interface PaymentServiceEvents {
+export interface PaymentServiceEvents {
   /**
    * Triggered when the service encounters an issue in an "asynchronous sub-process"  (like accepting payments)
    * that should be notified to the caller

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,4 +7,4 @@ export { jsonLogger } from "./logger/jsonLogger";
 export { nullLogger } from "./logger/nullLogger";
 export { defaultLogger } from "./logger/defaultLogger";
 export * as EnvUtils from "./env";
-export { Yagna, YagnaApi } from "./yagna/yagna";
+export { Yagna, YagnaApi, YagnaOptions } from "./yagna/yagna";


### PR DESCRIPTION
I'm not sure if it's OK to enable everything in `index.ts` using `export * ...`. But anyone can get to these elements using `import from golem-js/dist/...` so I guess it's not a big difference..?