### PR TITLE
fix: add the possibility to disable auto-prefixing with golem-js in default logger

### DIFF
--- a/src/utils/logger/defaultLogger.ts
+++ b/src/utils/logger/defaultLogger.ts
@@ -1,11 +1,34 @@
 import debugLogger from "debug";
 
+type DefaultLoggerOptions = {
+  /**
+   * Disables prefixing the root namespace with golem-js
+   *
+   * @default false
+   */
+  disableAutoPrefix: boolean;
+};
+
+function getNamespace(namespace: string, disablePrefix: boolean) {
+  if (disablePrefix) {
+    return namespace;
+  } else {
+    return namespace.startsWith("golem-js:") ? namespace : `golem-js:${namespace}`;
+  }
+}
+
 /**
  * Creates a logger that uses the debug library. This logger is used by default by all entities in the SDK.
- * If the namespace is not prefixed with `golem-js:`, it will be prefixed automatically.
- **/
-export function defaultLogger(namespace: string) {
-  const namespaceWithBase = namespace.startsWith("golem-js:") ? namespace : `golem-js:${namespace}`;
+ *
+ * If the namespace is not prefixed with `golem-js:`, it will be prefixed automatically - this can be controlled by `disableAutoPrefix` options.
+ */
+export function defaultLogger(
+  namespace: string,
+  opts: DefaultLoggerOptions = {
+    disableAutoPrefix: false,
+  },
+) {
+  const namespaceWithBase = getNamespace(namespace, opts.disableAutoPrefix);
   const logger = debugLogger(namespaceWithBase);
 
   function log(msg: string, ctx?: Record<string, unknown> | Error) {
@@ -37,7 +60,7 @@ export function defaultLogger(namespace: string) {
   }
 
   return {
-    child: (childNamespace: string) => defaultLogger(`${namespaceWithBase}:${childNamespace}`),
+    child: (childNamespace: string) => defaultLogger(`${namespaceWithBase}:${childNamespace}`, opts),
     info,
     error,
     warn,


### PR DESCRIPTION
We want to enable the "standalone task executor" to use the `defaultLogger` as before, but without prefixing all its logs with `golem-js`.

After the change the logs can look like this:

```
  golem-js:yagna Attaching error handler to internal axios instance +0ms
  golem-js:yagna Connecting to yagna +3ms
  golem-js:yagna Checking yagna version support +0ms
  task-executor Initializing task executor services... +0ms
  task-executor:payment Allocation b3fe219e-2cae-4521-9c3a-37010419ae8f has been created for address 0x46b10a05c376b17a8370ff7298c0584c0b8bd600 using payment platform erc20-goerli-tglm +0ms
  task-executor:agreement Agreement Pool Service has started +0ms
  task-executor:stats Stats service has started +0ms
  task-executor:storage Starting GFTP server +0ms
  task-executor:payment Payment Service has started +34ms
  task-executor:storage GFTP server spawned +8ms
  task-executor:storage GFTP Version: 0.14.0 (9f9be57b 2023-12-07 build #365) +2ms
  task-executor:market Demand published on the market +0ms
  task-executor:market New demand has been created { id: 'e9cb03e364da4aeaa802da7b6740c1cd-8207a0287c5cb84612161601056633ade6f3641578e6e4c2f06b1dbca472361d' } +0ms
  task-executor:market Market Service has started +2ms
  task-executor:work Task Service has started +0ms
  task-executor Task Executor has started { subnet: 'public', network: 'goerli', driver: 'erc20' } +858ms
```