### PR TITLE
fix(payments): fixed payment acceptance for big number amount

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -134,25 +134,33 @@ export class InvoiceReceived extends BaseEvent<{
   id: string;
   provider: ProviderInfo;
   agreementId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
 }> {}
 export class DebitNoteReceived extends BaseEvent<{
   id: string;
   agreementId: string;
   activityId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
   provider: ProviderInfo;
 }> {}
 export class PaymentAccepted extends BaseEvent<{
   id: string;
   agreementId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
   provider: ProviderInfo;
 }> {}
 export class DebitNoteAccepted extends BaseEvent<{
   id: string;
   agreementId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
   provider: ProviderInfo;
 }> {}
 export class PaymentFailed extends BaseEvent<{ id: string; agreementId: string; reason?: string }> {}

--- a/src/payment/agreement_payment_process.spec.ts
+++ b/src/payment/agreement_payment_process.spec.ts
@@ -35,7 +35,6 @@ describe("AgreementPaymentProcess", () => {
         when(allocationMock.id).thenReturn("1000");
         when(invoiceMock.amount).thenReturn(0.123);
         when(invoiceMock.amountPrecise).thenReturn("0.123");
-        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -55,7 +54,6 @@ describe("AgreementPaymentProcess", () => {
         when(invoiceMock.id).thenReturn("invoice-id");
         when(invoiceMock.agreementId).thenReturn("agreement-id");
         when(invoiceMock.amount).thenReturn(0.123);
-        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
 

--- a/src/payment/agreement_payment_process.spec.ts
+++ b/src/payment/agreement_payment_process.spec.ts
@@ -34,6 +34,8 @@ describe("AgreementPaymentProcess", () => {
       it("accepts a invoice in RECEIVED state", async () => {
         when(allocationMock.id).thenReturn("1000");
         when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -44,7 +46,7 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addInvoice(instance(invoiceMock));
 
         expect(success).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).called();
+        verify(invoiceMock.accept("0.123", "1000")).called();
         expect(process.isFinished()).toEqual(true);
       });
 
@@ -53,6 +55,8 @@ describe("AgreementPaymentProcess", () => {
         when(invoiceMock.id).thenReturn("invoice-id");
         when(invoiceMock.agreementId).thenReturn("agreement-id");
         when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -80,6 +84,7 @@ describe("AgreementPaymentProcess", () => {
         when(invoiceMock.id).thenReturn("invoice-id");
         when(invoiceMock.agreementId).thenReturn("agreement-id");
         when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Accepted);
         const allocation = instance(allocationMock);
 
@@ -97,7 +102,7 @@ describe("AgreementPaymentProcess", () => {
           ),
         );
 
-        verify(invoiceMock.accept(0.123, "1000")).never();
+        verify(invoiceMock.accept("0.123", "1000")).never();
         expect(process.isFinished()).toEqual(false);
       });
     });
@@ -108,6 +113,7 @@ describe("AgreementPaymentProcess", () => {
         const allocation = instance(allocationMock);
 
         when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
         when(invoiceMock.isSameAs(anything())).thenReturn(true);
 
@@ -120,7 +126,7 @@ describe("AgreementPaymentProcess", () => {
 
         // Simulate issue with accepting the first one
         const issue = new Error("Failed to accept in yagna");
-        when(invoiceMock.accept(0.123, "1000"))
+        when(invoiceMock.accept("0.123", "1000"))
           .thenReject(issue) // On first call
           .thenResolve(); // On second call
 
@@ -130,7 +136,7 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addInvoice(invoice);
 
         expect(success).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).twice();
+        verify(invoiceMock.accept("0.123", "1000")).twice();
         expect(process.isFinished()).toEqual(true);
       });
 
@@ -138,6 +144,7 @@ describe("AgreementPaymentProcess", () => {
         when(allocationMock.id).thenReturn("1000");
 
         when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
         when(invoiceMock.isSameAs(anything())).thenReturn(true);
 
@@ -148,14 +155,14 @@ describe("AgreementPaymentProcess", () => {
 
         const invoice = instance(invoiceMock);
 
-        when(invoiceMock.accept(0.123, "1000")).thenResolve();
+        when(invoiceMock.accept("0.123", "1000")).thenResolve();
 
         const firstSuccess = await process.addInvoice(invoice);
         const secondSuccess = await process.addInvoice(invoice);
 
         expect(firstSuccess).toEqual(true);
         expect(secondSuccess).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).twice();
+        verify(invoiceMock.accept("0.123", "1000")).twice();
         expect(process.isFinished()).toEqual(true);
       });
 
@@ -239,6 +246,7 @@ describe("AgreementPaymentProcess", () => {
       it("accepts a single debit note", async () => {
         when(allocationMock.id).thenReturn("1000");
         when(debitNoteMock.totalAmountDue).thenReturn(0.123);
+        when(debitNoteMock.totalAmountDuePrecise).thenReturn("0.123");
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
           debitNoteFilter: () => true,
@@ -250,13 +258,14 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addDebitNote(debitNote);
 
         expect(success).toEqual(true);
-        verify(debitNoteMock.accept(0.123, "1000")).called();
+        verify(debitNoteMock.accept("0.123", "1000")).called();
         expect(process.isFinished()).toEqual(false);
       });
 
       it("rejects debit note if it's ignored by the user defined debit note filter", async () => {
         when(allocationMock.id).thenReturn("1000");
         when(debitNoteMock.totalAmountDue).thenReturn(0.123);
+        when(debitNoteMock.totalAmountDuePrecise).thenReturn("0.123");
         when(debitNoteMock.id).thenReturn("debit-note-id");
         when(debitNoteMock.agreementId).thenReturn("agreement-id");
 
@@ -285,6 +294,7 @@ describe("AgreementPaymentProcess", () => {
       it("rejects debit note if there is already an invoice for that process", async () => {
         when(allocationMock.id).thenReturn("1000");
         when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amountPrecise).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve(InvoiceStatus.Received);
         when(debitNoteMock.totalAmountDue).thenReturn(0.456);
         when(debitNoteMock.id).thenReturn("debit-note-id");
@@ -302,7 +312,7 @@ describe("AgreementPaymentProcess", () => {
         const debitNoteSuccess = await process.addDebitNote(debitNote);
 
         expect(invoiceSuccess).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).called();
+        verify(invoiceMock.accept("0.123", "1000")).called();
 
         expect(debitNoteSuccess).toEqual(false);
         verify(
@@ -323,6 +333,7 @@ describe("AgreementPaymentProcess", () => {
       it("accepts the duplicated debit note if accepting the previous failed", async () => {
         when(allocationMock.id).thenReturn("1000");
         when(debitNoteMock.totalAmountDue).thenReturn(0.123);
+        when(debitNoteMock.totalAmountDuePrecise).thenReturn("0.123");
         when(debitNoteMock.getStatus()).thenResolve(InvoiceStatus.Received);
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -334,7 +345,7 @@ describe("AgreementPaymentProcess", () => {
 
         // Simulate issue with accepting the first one
         const issue = new Error("Failed to accept in yagna");
-        when(debitNoteMock.accept(0.123, "1000"))
+        when(debitNoteMock.accept("0.123", "1000"))
           .thenReject(issue) // On first call
           .thenResolve(); // On second call
 
@@ -344,7 +355,7 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addDebitNote(debitNote);
 
         expect(success).toEqual(true);
-        verify(debitNoteMock.accept(0.123, "1000")).twice();
+        verify(debitNoteMock.accept("0.123", "1000")).twice();
         expect(process.isFinished()).toEqual(false);
       });
 

--- a/src/payment/agreement_payment_process.ts
+++ b/src/payment/agreement_payment_process.ts
@@ -106,7 +106,7 @@ export class AgreementPaymentProcess {
       return false;
     }
 
-    await debitNote.accept(debitNote.totalAmountDue, this.allocation.id);
+    await debitNote.accept(debitNote.totalAmountDuePrecise, this.allocation.id);
     this.logger.debug(`DebitNote accepted`, {
       debitNoteId: debitNote.id,
       agreementId: debitNote.agreementId,
@@ -184,7 +184,7 @@ export class AgreementPaymentProcess {
       return false;
     }
 
-    await invoice.accept(invoice.amount, this.allocation.id);
+    await invoice.accept(invoice.amountPrecise, this.allocation.id);
     this.logger.info(`Invoice has been accepted`, {
       invoiceId: invoice.id,
       agreementId: invoice.agreementId,

--- a/src/payment/debit_note.ts
+++ b/src/payment/debit_note.ts
@@ -15,7 +15,9 @@ export interface DebitNoteDTO {
   timestamp: string;
   activityId: string;
   agreementId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `totalAmountDuePrecise` instead **/
   totalAmountDue: number;
+  totalAmountDuePrecise: string;
   usageCounterVector?: object;
 }
 
@@ -28,7 +30,11 @@ export class DebitNote extends BaseNote<Model> {
   public readonly previousDebitNoteId?: string;
   public readonly timestamp: string;
   public readonly activityId: string;
+  /**
+   * @deprecated this field may store invalid values for big numbers. Use totalAmountDuePrecise instead
+   */
   public readonly totalAmountDue: number;
+  public readonly totalAmountDuePrecise: string;
   public readonly usageCounterVector?: object;
 
   /**
@@ -70,6 +76,7 @@ export class DebitNote extends BaseNote<Model> {
     this.timestamp = model.timestamp;
     this.activityId = model.activityId;
     this.totalAmountDue = Number(model.totalAmountDue);
+    this.totalAmountDuePrecise = model.totalAmountDue;
     this.usageCounterVector = model.usageCounterVector;
   }
 
@@ -80,6 +87,7 @@ export class DebitNote extends BaseNote<Model> {
       activityId: this.activityId,
       agreementId: this.agreementId,
       totalAmountDue: this.totalAmountDue,
+      totalAmountDuePrecise: this.totalAmountDuePrecise,
       usageCounterVector: this.usageCounterVector,
     };
   }
@@ -90,10 +98,10 @@ export class DebitNote extends BaseNote<Model> {
    * @param totalAmountAccepted
    * @param allocationId
    */
-  async accept(totalAmountAccepted: number, allocationId: string) {
+  async accept(totalAmountAccepted: string, allocationId: string) {
     try {
       await this.yagnaApi.payment.acceptDebitNote(this.id, {
-        totalAmountAccepted: `${totalAmountAccepted}`,
+        totalAmountAccepted,
         allocationId,
       });
     } catch (error) {
@@ -113,7 +121,8 @@ export class DebitNote extends BaseNote<Model> {
       new Events.DebitNoteAccepted({
         id: this.id,
         agreementId: this.agreementId,
-        amount: totalAmountAccepted,
+        amount: Number(totalAmountAccepted),
+        amountPrecise: totalAmountAccepted,
         provider: this.provider,
       }),
     );

--- a/src/payment/invoice.spec.ts
+++ b/src/payment/invoice.spec.ts
@@ -6,6 +6,7 @@ import { RequestorApi as MarketRequestorApi } from "ya-ts-client/dist/ya-market/
 import { InvoiceStatus } from "ya-ts-client/dist/ya-payment/src/models";
 import { Agreement } from "ya-ts-client/dist/ya-market/src/models";
 import { GolemPaymentError, PaymentErrorCode } from "./error";
+import { Decimal } from "decimal.js-light";
 
 const mockYagnaApi = imock<YagnaApi>();
 const mockPaymentApi = mock(PaymentRequestorApi);
@@ -26,6 +27,33 @@ describe("Invoice", () => {
         },
       },
     } as Agreement,
+  });
+  describe("creating", () => {
+    test("create invoice with a big number amount", async () => {
+      when(mockPaymentApi.getInvoice("invoiceId")).thenResolve({
+        config: {},
+        headers: {},
+        status: 200,
+        statusText: "OK",
+        data: {
+          invoiceId: "invoiceId",
+          issuerId: "issuer-id",
+          payeeAddr: "0xPAYEE",
+          payerAddr: "0xPAYER",
+          recipientId: "recipient-id",
+          paymentPlatform: "holesky",
+          timestamp: "2023-01-01T00:00:00.000Z",
+          agreementId: "agreement-id",
+          status: InvoiceStatus.Received,
+          amount: "0.009551938349900001",
+          paymentDueDate: "2023-01-02T00:00:00.000Z",
+          activityIds: ["activity-1"],
+        },
+      });
+      when(mockYagnaApi.payment).thenReturn(instance(mockPaymentApi));
+      const invoice = await Invoice.create("invoiceId", instance(mockYagnaApi));
+      expect(new Decimal("0.009551938349900001").eq(new Decimal(invoice.amountPrecise))).toEqual(true);
+    });
   });
   describe("accepting", () => {
     test("throw GolemPaymentError if invoice cannot be accepted", async () => {
@@ -53,7 +81,7 @@ describe("Invoice", () => {
       when(mockPaymentApi.acceptInvoice("invoiceId", anything())).thenReject(errorYagnaApiMock);
       when(mockYagnaApi.payment).thenReturn(instance(mockPaymentApi));
       const invoice = await Invoice.create("invoiceId", instance(mockYagnaApi));
-      await expect(invoice.accept(1, "testAllocationId")).rejects.toMatchError(
+      await expect(invoice.accept("1", "testAllocationId")).rejects.toMatchError(
         new GolemPaymentError(
           `Unable to accept invoice invoiceId ${errorYagnaApiMock}`,
           PaymentErrorCode.InvoiceAcceptanceFailed,

--- a/src/payment/payments.ts
+++ b/src/payment/payments.ts
@@ -91,6 +91,7 @@ export class Payments extends EventTarget {
               id: invoice.id,
               agreementId: invoice.agreementId,
               amount: invoice.amount,
+              amountPrecise: invoice.amountPrecise,
               provider: invoice.provider,
             }),
           );
@@ -140,6 +141,7 @@ export class Payments extends EventTarget {
               agreementId: debitNote.agreementId,
               activityId: debitNote.activityId,
               amount: debitNote.totalAmountDue,
+              amountPrecise: debitNote.totalAmountDuePrecise,
               provider: debitNote.provider,
             }),
           );

--- a/src/payment/strategy.ts
+++ b/src/payment/strategy.ts
@@ -1,5 +1,6 @@
 import { DebitNoteDTO } from "./debit_note";
 import { InvoiceDTO } from "./invoice";
+import { Decimal } from "decimal.js-light";
 
 /** Default DebitNotes filter that accept all debit notes without any validation */
 export const acceptAllDebitNotesFilter = () => async () => true;
@@ -8,8 +9,8 @@ export const acceptAllInvoicesFilter = () => async () => true;
 
 /** A custom filter that only accepts debit notes below a given value */
 export const acceptMaxAmountDebitNoteFilter = (maxAmount: number) => async (debitNote: DebitNoteDTO) =>
-  debitNote.totalAmountDue <= maxAmount;
+  new Decimal(debitNote.totalAmountDuePrecise).lte(maxAmount);
 
 /** A custom filter that only accepts invoices below a given value */
 export const acceptMaxAmountInvoiceFilter = (maxAmount: number) => async (invoice: InvoiceDTO) =>
-  invoice.amount <= maxAmount;
+  new Decimal(invoice.amountPrecise).lte(maxAmount);

--- a/src/stats/invoices.ts
+++ b/src/stats/invoices.ts
@@ -4,13 +4,13 @@ import { ProviderInfo } from "../agreement";
 export interface InvoiceInfo {
   id: string;
   agreementId: string;
-  amount: number;
+  amount: string;
   provider: ProviderInfo;
 }
 interface Payload {
   id: string;
   agreementId: string;
-  amount: number;
+  amount: string;
   provider: ProviderInfo;
 }
 

--- a/src/stats/payments.ts
+++ b/src/stats/payments.ts
@@ -4,13 +4,13 @@ import { ProviderInfo } from "../agreement";
 export interface PaymentInfo {
   id: string;
   agreementId: string;
-  amount: number;
+  amount: string;
   provider: ProviderInfo;
 }
 interface Payload {
   id: string;
   agreementId: string;
-  amount: number;
+  amount: string;
   provider: ProviderInfo;
 }
 

--- a/src/stats/service.ts
+++ b/src/stats/service.ts
@@ -201,13 +201,13 @@ export class StatsService {
         id: event.detail.id,
         provider: event.detail.provider,
         agreementId: event.detail.agreementId,
-        amount: event.detail.amount,
+        amount: event.detail.amountPrecise,
       });
     } else if (event instanceof Events.PaymentAccepted) {
       this.payments.add({
         id: event.detail.id,
         agreementId: event.detail.agreementId,
-        amount: event.detail.amount,
+        amount: event.detail.amountPrecise,
         provider: event.detail.provider,
       });
     }

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -151,7 +151,7 @@ describe("Stats Module", () => {
       const tests = new Invoices();
       tests.add({
         id: "id",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId",
       });
@@ -159,7 +159,7 @@ describe("Stats Module", () => {
         new Collection([
           {
             id: "id",
-            amount: 100,
+            amount: "100",
             provider: testProvider,
             agreementId: "agreementId",
           },
@@ -170,19 +170,19 @@ describe("Stats Module", () => {
       const tests = new Invoices();
       tests.add({
         id: "id",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId",
       });
       tests.add({
         id: "id2",
-        amount: 100,
+        amount: "100",
         provider: testProvider2,
         agreementId: "agreementId2",
       });
       tests.add({
         id: "id3",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId3",
       });
@@ -192,19 +192,19 @@ describe("Stats Module", () => {
       const tests = new Invoices();
       tests.add({
         id: "id",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId",
       });
       tests.add({
         id: "id2",
-        amount: 100,
+        amount: "100",
         provider: testProvider2,
         agreementId: "agreementId2",
       });
       tests.add({
         id: "id3",
-        amount: 100,
+        amount: "100",
         provider: testProvider3,
         agreementId: "agreementId",
       });
@@ -216,7 +216,7 @@ describe("Stats Module", () => {
       const tests = new Payments();
       tests.add({
         id: "id",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId",
       });
@@ -224,7 +224,7 @@ describe("Stats Module", () => {
         new Collection([
           {
             id: "id",
-            amount: 100,
+            amount: "100",
             provider: testProvider,
             agreementId: "agreementId",
           },
@@ -235,19 +235,19 @@ describe("Stats Module", () => {
       const tests = new Payments();
       tests.add({
         id: "id",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId",
       });
       tests.add({
         id: "id2",
-        amount: 100,
+        amount: "100",
         provider: testProvider2,
         agreementId: "agreementId2",
       });
       tests.add({
         id: "id3",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId3",
       });
@@ -257,19 +257,19 @@ describe("Stats Module", () => {
       const tests = new Payments();
       tests.add({
         id: "id",
-        amount: 100,
+        amount: "100",
         provider: testProvider,
         agreementId: "agreementId",
       });
       tests.add({
         id: "id2",
-        amount: 100,
+        amount: "100",
         provider: testProvider2,
         agreementId: "agreementId2",
       });
       tests.add({
         id: "id3",
-        amount: 100,
+        amount: "100",
         provider: testProvider3,
         agreementId: "agreementId",
       });

--- a/tests/unit/stats_service.test.ts
+++ b/tests/unit/stats_service.test.ts
@@ -130,13 +130,14 @@ describe("Stats Service", () => {
         provider: testProvider,
         agreementId: "agreementId",
         amount: 100,
+        amountPrecise: "100",
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({
         id: "id",
         provider: testProvider,
         agreementId: "agreementId",
-        amount: 100,
+        amount: "100",
       });
     });
     // Payments
@@ -147,13 +148,14 @@ describe("Stats Service", () => {
         provider: testProvider,
         agreementId: "agreementId",
         amount: 100,
+        amountPrecise: "100",
       });
       eventTarget.dispatchEvent(event);
       expect(spy).toHaveBeenCalledWith({
         id: "id",
         provider: testProvider,
         agreementId: "agreementId",
-        amount: 100,
+        amount: "100",
       });
     });
     // Providers


### PR DESCRIPTION
Added `amountPrecise` in Invoice and `totalAmountDuePrecise` in DebitNote. The old fields `amount` and `totalAmountDue` are marked as **deprecated**.
The number type caused problems for big numbers. The new `amountPrecise` and `totalAmountDuePrecise` fields are of the string type, and it is recommended to use them instead of the ones mentioned above. Payment events also have new fields for storing `amountPrecise` values.