### PR TITLE
Master -> beta sync

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -81,25 +81,33 @@ export class InvoiceReceived extends BaseEvent<{
   id: string;
   provider: ProviderInfo;
   agreementId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
 }> {}
 export class DebitNoteReceived extends BaseEvent<{
   id: string;
   agreementId: string;
   activityId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
   provider: ProviderInfo;
 }> {}
 export class PaymentAccepted extends BaseEvent<{
   id: string;
   agreementId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
   provider: ProviderInfo;
 }> {}
 export class DebitNoteAccepted extends BaseEvent<{
   id: string;
   agreementId: string;
+  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
   amount: number;
+  amountPrecise: string;
   provider: ProviderInfo;
 }> {}
 export class PaymentFailed extends BaseEvent<{ id: string; agreementId: string; reason?: string }> {}

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -81,33 +81,25 @@ export class InvoiceReceived extends BaseEvent<{
   id: string;
   provider: ProviderInfo;
   agreementId: string;
-  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
-  amount: number;
-  amountPrecise: string;
+  amount: string;
 }> {}
 export class DebitNoteReceived extends BaseEvent<{
   id: string;
   agreementId: string;
   activityId: string;
-  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
-  amount: number;
-  amountPrecise: string;
+  amount: string;
   provider: ProviderInfo;
 }> {}
 export class PaymentAccepted extends BaseEvent<{
   id: string;
   agreementId: string;
-  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
-  amount: number;
-  amountPrecise: string;
+  amount: string;
   provider: ProviderInfo;
 }> {}
 export class DebitNoteAccepted extends BaseEvent<{
   id: string;
   agreementId: string;
-  /** @deprecated this field may store invalid values for big numbers. Use `amountPrecise` instead **/
-  amount: number;
-  amountPrecise: string;
+  amount: string;
   provider: ProviderInfo;
 }> {}
 export class PaymentFailed extends BaseEvent<{ id: string; agreementId: string; reason?: string }> {}

--- a/src/payment/agreement_payment_process.spec.ts
+++ b/src/payment/agreement_payment_process.spec.ts
@@ -32,7 +32,7 @@ describe("AgreementPaymentProcess", () => {
     describe("Basic use cases", () => {
       it("accepts a invoice in RECEIVED state", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amount).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve("RECEIVED");
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -43,7 +43,7 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addInvoice(instance(invoiceMock));
 
         expect(success).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).called();
+        verify(invoiceMock.accept("0.123", "1000")).called();
         expect(process.isFinished()).toEqual(true);
       });
 
@@ -51,7 +51,7 @@ describe("AgreementPaymentProcess", () => {
         when(allocationMock.id).thenReturn("1000");
         when(invoiceMock.id).thenReturn("invoice-id");
         when(invoiceMock.agreementId).thenReturn("agreement-id");
-        when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amount).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve("RECEIVED");
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -78,7 +78,7 @@ describe("AgreementPaymentProcess", () => {
         when(allocationMock.id).thenReturn("1000");
         when(invoiceMock.id).thenReturn("invoice-id");
         when(invoiceMock.agreementId).thenReturn("agreement-id");
-        when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amount).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve("ACCEPTED");
         const allocation = instance(allocationMock);
 
@@ -96,7 +96,7 @@ describe("AgreementPaymentProcess", () => {
           ),
         );
 
-        verify(invoiceMock.accept(0.123, "1000")).never();
+        verify(invoiceMock.accept("0.123", "1000")).never();
         expect(process.isFinished()).toEqual(false);
       });
     });
@@ -106,7 +106,7 @@ describe("AgreementPaymentProcess", () => {
         when(allocationMock.id).thenReturn("1000");
         const allocation = instance(allocationMock);
 
-        when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amount).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve("RECEIVED");
         when(invoiceMock.isSameAs(anything())).thenReturn(true);
 
@@ -119,7 +119,7 @@ describe("AgreementPaymentProcess", () => {
 
         // Simulate issue with accepting the first one
         const issue = new Error("Failed to accept in yagna");
-        when(invoiceMock.accept(0.123, "1000"))
+        when(invoiceMock.accept("0.123", "1000"))
           .thenReject(issue) // On first call
           .thenResolve(); // On second call
 
@@ -129,14 +129,14 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addInvoice(invoice);
 
         expect(success).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).twice();
+        verify(invoiceMock.accept("0.123", "1000")).twice();
         expect(process.isFinished()).toEqual(true);
       });
 
       it("accepts the duplicate if the original invoice has not been already decided upon (still in RECEIVED state)", async () => {
         when(allocationMock.id).thenReturn("1000");
 
-        when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amount).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve("RECEIVED");
         when(invoiceMock.isSameAs(anything())).thenReturn(true);
 
@@ -147,14 +147,14 @@ describe("AgreementPaymentProcess", () => {
 
         const invoice = instance(invoiceMock);
 
-        when(invoiceMock.accept(0.123, "1000")).thenResolve();
+        when(invoiceMock.accept("0.123", "1000")).thenResolve();
 
         const firstSuccess = await process.addInvoice(invoice);
         const secondSuccess = await process.addInvoice(invoice);
 
         expect(firstSuccess).toEqual(true);
         expect(secondSuccess).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).twice();
+        verify(invoiceMock.accept("0.123", "1000")).twice();
         expect(process.isFinished()).toEqual(true);
       });
 
@@ -237,7 +237,7 @@ describe("AgreementPaymentProcess", () => {
     describe("Basic use cases", () => {
       it("accepts a single debit note", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(debitNoteMock.totalAmountDue).thenReturn(0.123);
+        when(debitNoteMock.totalAmountDue).thenReturn("0.123");
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
           debitNoteFilter: () => true,
@@ -249,13 +249,14 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addDebitNote(debitNote);
 
         expect(success).toEqual(true);
-        verify(debitNoteMock.accept(0.123, "1000")).called();
+        verify(debitNoteMock.accept("0.123", "1000")).called();
         expect(process.isFinished()).toEqual(false);
       });
 
       it("rejects debit note if it's ignored by the user defined debit note filter", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(debitNoteMock.totalAmountDue).thenReturn(0.123);
+        when(debitNoteMock.totalAmountDue).thenReturn("0.123");
+
         when(debitNoteMock.id).thenReturn("debit-note-id");
         when(debitNoteMock.agreementId).thenReturn("agreement-id");
 
@@ -283,9 +284,9 @@ describe("AgreementPaymentProcess", () => {
 
       it("rejects debit note if there is already an invoice for that process", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(invoiceMock.amount).thenReturn(0.123);
+        when(invoiceMock.amount).thenReturn("0.123");
         when(invoiceMock.getStatus()).thenResolve("RECEIVED");
-        when(debitNoteMock.totalAmountDue).thenReturn(0.456);
+        when(debitNoteMock.totalAmountDue).thenReturn("0.456");
         when(debitNoteMock.id).thenReturn("debit-note-id");
         when(debitNoteMock.agreementId).thenReturn("agreement-id");
 
@@ -301,7 +302,7 @@ describe("AgreementPaymentProcess", () => {
         const debitNoteSuccess = await process.addDebitNote(debitNote);
 
         expect(invoiceSuccess).toEqual(true);
-        verify(invoiceMock.accept(0.123, "1000")).called();
+        verify(invoiceMock.accept("0.123", "1000")).called();
 
         expect(debitNoteSuccess).toEqual(false);
         verify(
@@ -321,7 +322,7 @@ describe("AgreementPaymentProcess", () => {
     describe("Dealing with duplicates", () => {
       it("accepts the duplicated debit note if accepting the previous failed", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(debitNoteMock.totalAmountDue).thenReturn(0.123);
+        when(debitNoteMock.totalAmountDue).thenReturn("0.123");
         when(debitNoteMock.getStatus()).thenResolve("RECEIVED");
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {
@@ -333,7 +334,7 @@ describe("AgreementPaymentProcess", () => {
 
         // Simulate issue with accepting the first one
         const issue = new Error("Failed to accept in yagna");
-        when(debitNoteMock.accept(0.123, "1000"))
+        when(debitNoteMock.accept("0.123", "1000"))
           .thenReject(issue) // On first call
           .thenResolve(); // On second call
 
@@ -343,7 +344,7 @@ describe("AgreementPaymentProcess", () => {
         const success = await process.addDebitNote(debitNote);
 
         expect(success).toEqual(true);
-        verify(debitNoteMock.accept(0.123, "1000")).twice();
+        verify(debitNoteMock.accept("0.123", "1000")).twice();
         expect(process.isFinished()).toEqual(false);
       });
 
@@ -369,7 +370,7 @@ describe("AgreementPaymentProcess", () => {
     describe("Security", () => {
       it("throws an UserError in case of error in the debitNote filter", async () => {
         when(allocationMock.id).thenReturn("1000");
-        when(debitNoteMock.totalAmountDue).thenReturn(0.123);
+        when(debitNoteMock.totalAmountDue).thenReturn("0.123");
         when(debitNoteMock.getStatus()).thenResolve("RECEIVED");
 
         const process = new AgreementPaymentProcess(instance(agreementMock), instance(allocationMock), {

--- a/src/payment/debit_note.spec.ts
+++ b/src/payment/debit_note.spec.ts
@@ -3,7 +3,7 @@ import { anything, imock, instance, mock, objectContaining, reset, verify, when 
 import { YagnaApi } from "../utils";
 import { MarketApi, PaymentApi } from "ya-ts-client";
 import { GolemPaymentError, PaymentErrorCode } from "./error";
-import { Decimal } from "decimal.js-light";
+import Decimal from "decimal.js-light";
 
 const mockYagna = mock(YagnaApi);
 const mockPayment = mock(PaymentApi.RequestorService);

--- a/src/payment/debit_note.spec.ts
+++ b/src/payment/debit_note.spec.ts
@@ -3,6 +3,7 @@ import { anything, imock, instance, mock, objectContaining, reset, verify, when 
 import { YagnaApi } from "../utils";
 import { MarketApi, PaymentApi } from "ya-ts-client";
 import { GolemPaymentError, PaymentErrorCode } from "./error";
+import { Decimal } from "decimal.js-light";
 
 const mockYagna = mock(YagnaApi);
 const mockPayment = mock(PaymentApi.RequestorService);
@@ -24,6 +25,7 @@ describe("Debit Notes", () => {
     when(mockDebitNote.payeeAddr).thenReturn("0x12345");
     when(mockDebitNote.issuerId).thenReturn("0x123");
     when(mockDebitNote.agreementId).thenReturn("agreementId");
+    when(mockDebitNote.totalAmountDue).thenReturn("1");
 
     when(mockAgreement.agreementId).thenReturn("agreementId");
     when(mockAgreement.offer).thenReturn({
@@ -44,12 +46,17 @@ describe("Debit Notes", () => {
       const debitNote = await DebitNote.create("testId", instance(mockYagna));
       expect(debitNote).toBeDefined();
     });
+    it("should crete debit note with a big number amount", async () => {
+      when(mockDebitNote.totalAmountDue).thenReturn("0.009551938349900001");
+      const debitNote = await DebitNote.create("testId", instance(mockYagna));
+      expect(new Decimal("0.009551938349900001").eq(new Decimal(debitNote.totalAmountDue))).toEqual(true);
+    });
   });
 
   describe("accepting", () => {
     it("should accept debit note", async () => {
       const debitNote = await DebitNote.create("testId", instance(mockYagna));
-      await debitNote.accept(1, "testId");
+      await debitNote.accept("1", "testId");
       verify(mockPayment.acceptDebitNote("testId", objectContaining({ totalAmountAccepted: "1" }))).once();
     });
 
@@ -59,7 +66,7 @@ describe("Debit Notes", () => {
 
       const debitNote = await DebitNote.create("testId", instance(mockYagna));
 
-      await expect(debitNote.accept(1, "testId")).rejects.toMatchError(
+      await expect(debitNote.accept("1", "testId")).rejects.toMatchError(
         new GolemPaymentError(
           `Unable to accept debit note testId. ${errorYagnaApiMock}`,
           PaymentErrorCode.DebitNoteAcceptanceFailed,

--- a/src/payment/debit_note.ts
+++ b/src/payment/debit_note.ts
@@ -9,7 +9,7 @@ import { ProposalProperties } from "../market/proposal";
 import { EventEmitter } from "eventemitter3";
 
 export interface DebitNoteEvents {
-  accepted: (details: { id: string; agreementId: string; amount: number; provider: ProviderInfo }) => void;
+  accepted: (details: { id: string; agreementId: string; amount: string; provider: ProviderInfo }) => void;
   paymentFailed: (details: { id: string; agreementId: string; reason: string | undefined }) => void;
 }
 
@@ -20,7 +20,7 @@ export interface DebitNoteDTO {
   timestamp: string;
   activityId: string;
   agreementId: string;
-  totalAmountDue: number;
+  totalAmountDue: string;
   usageCounterVector?: object;
 }
 
@@ -33,7 +33,7 @@ export class DebitNote extends BaseNote<PaymentApi.DebitNoteDTO> {
   public readonly previousDebitNoteId?: string;
   public readonly timestamp: string;
   public readonly activityId: string;
-  public readonly totalAmountDue: number;
+  public readonly totalAmountDue: string;
   public readonly usageCounterVector?: object;
   public readonly events = new EventEmitter<DebitNoteEvents>();
 
@@ -75,7 +75,7 @@ export class DebitNote extends BaseNote<PaymentApi.DebitNoteDTO> {
     this.id = model.debitNoteId;
     this.timestamp = model.timestamp;
     this.activityId = model.activityId;
-    this.totalAmountDue = Number(model.totalAmountDue);
+    this.totalAmountDue = model.totalAmountDue;
     this.usageCounterVector = model.usageCounterVector;
   }
 
@@ -96,10 +96,10 @@ export class DebitNote extends BaseNote<PaymentApi.DebitNoteDTO> {
    * @param totalAmountAccepted
    * @param allocationId
    */
-  async accept(totalAmountAccepted: number, allocationId: string) {
+  async accept(totalAmountAccepted: string, allocationId: string) {
     try {
       await this.yagnaApi.payment.acceptDebitNote(this.id, {
-        totalAmountAccepted: `${totalAmountAccepted}`,
+        totalAmountAccepted,
         allocationId,
       });
     } catch (error) {

--- a/src/payment/invoice.spec.ts
+++ b/src/payment/invoice.spec.ts
@@ -3,7 +3,7 @@ import { anything, imock, instance, mock, reset, when } from "@johanblumenberg/t
 import { YagnaApi } from "../utils";
 import { PaymentApi, MarketApi } from "ya-ts-client";
 import { GolemPaymentError, PaymentErrorCode } from "./error";
-import { Decimal } from "decimal.js-light";
+import Decimal from "decimal.js-light";
 
 const mockYagna = mock(YagnaApi);
 const mockPayment = mock(PaymentApi.RequestorService);

--- a/src/payment/invoice.spec.ts
+++ b/src/payment/invoice.spec.ts
@@ -3,6 +3,7 @@ import { anything, imock, instance, mock, reset, when } from "@johanblumenberg/t
 import { YagnaApi } from "../utils";
 import { PaymentApi, MarketApi } from "ya-ts-client";
 import { GolemPaymentError, PaymentErrorCode } from "./error";
+import { Decimal } from "decimal.js-light";
 
 const mockYagna = mock(YagnaApi);
 const mockPayment = mock(PaymentApi.RequestorService);
@@ -44,6 +45,27 @@ describe("Invoice", () => {
     });
   });
 
+  describe("creating", () => {
+    test("create invoice with a big number amount", async () => {
+      when(mockPayment.getInvoice("invoiceId")).thenResolve({
+        invoiceId: "invoiceId",
+        issuerId: "issuer-id",
+        payeeAddr: "0xPAYEE",
+        payerAddr: "0xPAYER",
+        recipientId: "recipient-id",
+        paymentPlatform: "holesky",
+        timestamp: "2023-01-01T00:00:00.000Z",
+        agreementId: "agreement-id",
+        status: "RECEIVED",
+        amount: "0.009551938349900001",
+        paymentDueDate: "2023-01-02T00:00:00.000Z",
+        activityIds: ["activity-1"],
+      });
+      const invoice = await Invoice.create("invoiceId", instance(mockYagna));
+      expect(new Decimal("0.009551938349900001").eq(new Decimal(invoice.amount))).toEqual(true);
+    });
+  });
+
   describe("accepting", () => {
     test("throw GolemPaymentError if invoice cannot be accepted", async () => {
       const errorYagnaApiMock = new Error("test error");
@@ -51,7 +73,7 @@ describe("Invoice", () => {
 
       const invoice = await Invoice.create("invoiceId", instance(mockYagna));
 
-      await expect(invoice.accept(1, "testAllocationId")).rejects.toMatchError(
+      await expect(invoice.accept("1", "testAllocationId")).rejects.toMatchError(
         new GolemPaymentError(
           `Unable to accept invoice invoiceId ${errorYagnaApiMock}`,
           PaymentErrorCode.InvoiceAcceptanceFailed,

--- a/src/payment/invoice.ts
+++ b/src/payment/invoice.ts
@@ -8,7 +8,7 @@ import { ProposalProperties } from "../market/proposal";
 import { EventEmitter } from "eventemitter3";
 
 export interface InvoiceEvents {
-  accepted: (details: { id: string; agreementId: string; amount: number; provider: ProviderInfo }) => void;
+  accepted: (details: { id: string; agreementId: string; amount: string; provider: ProviderInfo }) => void;
   paymentFailed: (details: { id: string; agreementId: string; reason: string | undefined }) => void;
 }
 
@@ -24,7 +24,7 @@ export interface InvoiceDTO {
   requestorWalletAddress: string;
   provider: ProviderInfo;
   paymentPlatform: string;
-  amount: number;
+  amount: string;
 }
 
 /**
@@ -82,7 +82,7 @@ export abstract class BaseNote<ModelType extends BaseModel> {
       );
     }
   }
-  protected abstract accept(totalAmountAccepted: number, allocationId: string): Promise<void>;
+  protected abstract accept(totalAmountAccepted: string, allocationId: string): Promise<void>;
   protected abstract reject(rejection: Rejection): Promise<void>;
   protected abstract refreshStatus(): Promise<void>;
 }
@@ -97,7 +97,7 @@ export class Invoice extends BaseNote<PaymentApi.InvoiceDTO> {
   /** Activities IDs covered by this Invoice */
   public readonly activityIds?: string[];
   /** Amount in the invoice */
-  public readonly amount: number;
+  public readonly amount: string;
   /** Invoice creation timestamp */
   public readonly timestamp: string;
   /** Recipient ID */
@@ -139,7 +139,7 @@ export class Invoice extends BaseNote<PaymentApi.InvoiceDTO> {
     super(model, providerInfo, options);
     this.id = model.invoiceId;
     this.activityIds = model.activityIds;
-    this.amount = Number(model.amount);
+    this.amount = model.amount;
     this.timestamp = model.timestamp;
     this.recipientId = model.recipientId;
   }
@@ -175,10 +175,10 @@ export class Invoice extends BaseNote<PaymentApi.InvoiceDTO> {
    * @param totalAmountAccepted
    * @param allocationId
    */
-  async accept(totalAmountAccepted: number, allocationId: string) {
+  async accept(totalAmountAccepted: string, allocationId: string) {
     try {
       await this.yagnaApi.payment.acceptInvoice(this.id, {
-        totalAmountAccepted: `${totalAmountAccepted}`,
+        totalAmountAccepted,
         allocationId,
       });
     } catch (error) {

--- a/src/payment/strategy.test.ts
+++ b/src/payment/strategy.test.ts
@@ -30,9 +30,9 @@ describe("SDK provided Payment Filters", () => {
   describe("acceptMaxAmountDebitNoteFilter", () => {
     test("Accepts debit notes that don't exceed a specified amount", async () => {
       const mockDebitNoteDto0 = imock<DebitNoteDTO>();
-      when(mockDebitNoteDto0.totalAmountDue).thenReturn(100);
+      when(mockDebitNoteDto0.totalAmountDue).thenReturn("100");
       const mockDebitNoteDto1 = imock<DebitNoteDTO>();
-      when(mockDebitNoteDto1.totalAmountDue).thenReturn(200);
+      when(mockDebitNoteDto1.totalAmountDue).thenReturn("200");
       const debitNotes = [instance(mockDebitNoteDto0), instance(mockDebitNoteDto1)];
 
       const filter = acceptMaxAmountDebitNoteFilter(150);
@@ -43,16 +43,16 @@ describe("SDK provided Payment Filters", () => {
         }
       }
       expect(accepted.length).toEqual(1);
-      expect(accepted[0].totalAmountDue).toEqual(100);
+      expect(accepted[0].totalAmountDue).toEqual("100");
     });
   });
 
   describe("acceptMaxAmountInvoiceFilter", () => {
     test("Accepts invoices that don't exceed a specified amount", async () => {
       const mockInvoiceDto0 = imock<InvoiceDTO>();
-      when(mockInvoiceDto0.amount).thenReturn(100);
+      when(mockInvoiceDto0.amount).thenReturn("100");
       const mockInvoiceDto1 = imock<InvoiceDTO>();
-      when(mockInvoiceDto1.amount).thenReturn(200);
+      when(mockInvoiceDto1.amount).thenReturn("200");
       const invoices = [instance(mockInvoiceDto0), instance(mockInvoiceDto1)];
 
       const filter = acceptMaxAmountInvoiceFilter(150);
@@ -63,7 +63,7 @@ describe("SDK provided Payment Filters", () => {
         }
       }
       expect(accepted.length).toEqual(1);
-      expect(accepted[0].amount).toEqual(100);
+      expect(accepted[0].amount).toEqual("100");
     });
   });
 });

--- a/src/payment/strategy.ts
+++ b/src/payment/strategy.ts
@@ -1,6 +1,6 @@
 import { DebitNoteDTO } from "./debit_note";
 import { InvoiceDTO } from "./invoice";
-import { Decimal } from "decimal.js-light";
+import Decimal from "decimal.js-light";
 
 /** Default DebitNotes filter that accept all debit notes without any validation */
 export const acceptAllDebitNotesFilter = () => async () => true;

--- a/src/payment/strategy.ts
+++ b/src/payment/strategy.ts
@@ -1,5 +1,6 @@
 import { DebitNoteDTO } from "./debit_note";
 import { InvoiceDTO } from "./invoice";
+import { Decimal } from "decimal.js-light";
 
 /** Default DebitNotes filter that accept all debit notes without any validation */
 export const acceptAllDebitNotesFilter = () => async () => true;
@@ -9,8 +10,8 @@ export const acceptAllInvoicesFilter = () => async () => true;
 
 /** A custom filter that only accepts debit notes below a given value */
 export const acceptMaxAmountDebitNoteFilter = (maxAmount: number) => async (debitNote: DebitNoteDTO) =>
-  debitNote.totalAmountDue <= maxAmount;
+  new Decimal(debitNote.totalAmountDue).lte(maxAmount);
 
 /** A custom filter that only accepts invoices below a given value */
 export const acceptMaxAmountInvoiceFilter = (maxAmount: number) => async (invoice: InvoiceDTO) =>
-  invoice.amount <= maxAmount;
+  new Decimal(invoice.amount).lte(maxAmount);


### PR DESCRIPTION
fix(payments): restoring string types for the amount and totalAmountDue fields

BREAKING CHANGE: Removed the `amountPrecise` field in `Invoice` and
`totalAmountDuePrecise` in `DebitNote`. Now the old `amount` and
`totalAmountDue` fields are of the string type, so the above will be
unnecessary.