### PR TITLE
Deposit in allocation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "tmp": "^0.2.2",
         "uuid": "^9.0.1",
         "ws": "^8.16.0",
-        "ya-ts-client": "^1.0.0"
+        "ya-ts-client": "^1.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.0.3",
@@ -19356,9 +19356,9 @@
       }
     },
     "node_modules/ya-ts-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ya-ts-client/-/ya-ts-client-1.0.0.tgz",
-      "integrity": "sha512-rWoWrMOiyZetcB8xbv6oY0J45zOO6eDluHEZMk4kxGaqYKV681bg6y2N61sjGcB+l9I/8RC2LYtvl4tjkqsuiA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ya-ts-client/-/ya-ts-client-1.1.0.tgz",
+      "integrity": "sha512-5NeC08K9B6JQt/i2ndyZ7Xe4NuY+NuInvUFd58nICSsWibNdvGhdcXaeSLDxMXO55TnoPtITAfodkc0X/YifRA==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tmp": "^0.2.2",
     "uuid": "^9.0.1",
     "ws": "^8.16.0",
-    "ya-ts-client": "^1.0.0"
+    "ya-ts-client": "^1.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.3",

--- a/src/payment/allocation.ts
+++ b/src/payment/allocation.ts
@@ -13,6 +13,10 @@ export interface AllocationOptions extends BasePaymentOptions {
     platform: string;
   };
   expirationSec?: number;
+  deposit?: {
+    contract: string;
+    id: string;
+  };
 }
 
 /**
@@ -52,6 +56,7 @@ export class Allocation {
         remainingAmount: "",
         spentAmount: "",
         allocationId: "",
+        deposit: config.deposit,
       };
       const newModel = await yagnaApi.payment.createAllocation(model);
       config.logger.debug(

--- a/src/payment/allocation.ts
+++ b/src/payment/allocation.ts
@@ -13,8 +13,20 @@ export interface AllocationOptions extends BasePaymentOptions {
     platform: string;
   };
   expirationSec?: number;
+  /**
+   * Optionally provide a deposit to be used for the allocation, instead of using funds from the yagna wallet.
+   * Deposit is a way to pay for the computation using someone else's funds. Learn more about deposits and allowance
+   * in the [official documentation](https://docs.golem.network/creators/javascript/tutorials/allowance).
+   * TODO: actually write the tutorial about deposits and allowance
+   */
   deposit?: {
+    /**
+     * Address of the smart contract that holds the deposit.
+     */
     contract: string;
+    /**
+     * ID of the deposit, obtained by calling the `createDeposit` method on the smart contract.
+     */
     id: string;
   };
 }

--- a/src/payment/config.ts
+++ b/src/payment/config.ts
@@ -59,6 +59,7 @@ export class PaymentConfig extends BaseConfig {
   public readonly unsubscribeTimeoutMs: number;
   public readonly debitNoteFilter: DebitNoteFilter;
   public readonly invoiceFilter: InvoiceFilter;
+  public readonly allocation?: Partial<AllocationOptions>;
 
   constructor(options?: PaymentOptions) {
     super(options);
@@ -69,6 +70,7 @@ export class PaymentConfig extends BaseConfig {
     this.unsubscribeTimeoutMs = options?.unsubscribeTimeoutMs ?? DEFAULTS.unsubscribeTimeoutMs;
     this.debitNoteFilter = options?.debitNotesFilter ?? DEFAULTS.debitNoteFilter;
     this.invoiceFilter = options?.invoiceFilter ?? DEFAULTS.invoiceFilter;
+    this.allocation = options?.allocation;
   }
 }
 /**
@@ -79,6 +81,7 @@ export class AllocationConfig extends BaseConfig {
   public readonly payment: { driver: string; network: string };
   public readonly expirationSec: number;
   public readonly account: { address: string; platform: string };
+  public readonly deposit?: { contract: string; id: string };
 
   constructor(options?: AllocationOptions) {
     super(options);
@@ -100,6 +103,8 @@ export class AllocationConfig extends BaseConfig {
     };
 
     this.expirationSec = options?.expirationSec || DEFAULTS.allocationExpirationSec;
+
+    this.deposit = options?.deposit;
   }
 }
 /**

--- a/src/payment/service.ts
+++ b/src/payment/service.ts
@@ -33,6 +33,7 @@ export interface PaymentOptions extends BasePaymentOptions {
   debitNotesFilter?: DebitNoteFilter;
   /** A custom filter that checks every invoices coming from providers */
   invoiceFilter?: InvoiceFilter;
+  allocation?: Partial<AllocationOptions>;
 }
 
 export type DebitNoteFilter = (debitNote: DebitNoteDTO) => Promise<boolean> | boolean;
@@ -111,7 +112,12 @@ export class PaymentService {
         platform: this.getPaymentPlatform(),
         address: await this.getPaymentAddress(),
       };
-      this.allocation = await Allocation.create(this.yagnaApi, { ...this.config.options, account, ...options });
+      this.allocation = await Allocation.create(this.yagnaApi, {
+        ...this.config.options,
+        account,
+        ...(this.config?.allocation || {}),
+        ...options,
+      });
       this.events.emit("allocationCreated", this.allocation);
       return this.allocation;
     } catch (error) {

--- a/src/payment/service.ts
+++ b/src/payment/service.ts
@@ -113,9 +113,9 @@ export class PaymentService {
         address: await this.getPaymentAddress(),
       };
       this.allocation = await Allocation.create(this.yagnaApi, {
-        ...this.config.options,
         account,
-        ...(this.config?.allocation || {}),
+        ...this.config.options,
+        ...this.config.allocation,
         ...options,
       });
       this.events.emit("allocationCreated", this.allocation);

--- a/src/payment/service.ts
+++ b/src/payment/service.ts
@@ -33,6 +33,10 @@ export interface PaymentOptions extends BasePaymentOptions {
   debitNotesFilter?: DebitNoteFilter;
   /** A custom filter that checks every invoices coming from providers */
   invoiceFilter?: InvoiceFilter;
+  /** Additional options that will be used when creating an allocation. Learn more: {@link AllocationOptions}.
+   * Keep in mind that you can override these options on a per-allocation basis when creating an allocation
+   * by passing additional options to {@link PaymentService.createAllocation}
+   */
   allocation?: Partial<AllocationOptions>;
 }
 


### PR DESCRIPTION
The deposit details can be added when calling `paymentService.createAllocation` :
```ts
  const allocation = await payment.createAllocation({
    budget: 1.0,
    expirationSec: DURATION_SEC,
    deposit: {
      contract: "0x...",
      id: "0x...",
    }
  });
```

I also added `AllocationOptions` to `PaymentOptions` so it can be added to TE:
```ts
 const executor = await TaskExecutor.create({
    package: "golem/alpine:latest",
    logger: pinoPrettyLogger(),
    allocation: {
      deposit: {
        contract: "0x...",
        id: "0x...",
      },
    },
  });
  ```
  
  related to: JST-829