### PR TITLE
fix(lease-process): fixed finalizing already terminated agreements

### DIFF
--- a/src/lease-process/lease-process.ts
+++ b/src/lease-process/lease-process.ts
@@ -59,7 +59,9 @@ export class LeaseProcess {
       this.logger.debug("Waiting for payment process of agreement to finish", { agreementId: this.agreement.id });
       if (this.currentWorkContext) {
         await this.activityModule.destroyActivity(this.currentWorkContext.activity);
-        await this.marketModule.terminateAgreement(this.agreement);
+        if ((await this.fetchAgreementState()) !== "Terminated") {
+          await this.marketModule.terminateAgreement(this.agreement);
+        }
       }
       await waitForCondition(() => this.paymentProcess.isFinished());
       this.logger.debug("Payment process for agreement finalized", { agreementId: this.agreement.id });

--- a/src/market/agreement/agreement.ts
+++ b/src/market/agreement/agreement.ts
@@ -68,9 +68,4 @@ export class Agreement {
     const state = this.getState();
     return state !== "Pending" && state !== "Proposal";
   }
-
-  canBeTerminated(): boolean {
-    const state = this.getState();
-    return state !== "Rejected" && state !== "Cancelled" && state !== "Terminated";
-  }
 }

--- a/src/market/agreement/agreement.ts
+++ b/src/market/agreement/agreement.ts
@@ -64,8 +64,13 @@ export class Agreement {
    * @description if the final state is true, agreement will not change state further anymore
    * @return boolean
    */
-  async isFinalState(): Promise<boolean> {
+  isFinalState(): boolean {
     const state = this.getState();
     return state !== "Pending" && state !== "Proposal";
+  }
+
+  canBeTerminated(): boolean {
+    const state = this.getState();
+    return state !== "Rejected" && state !== "Cancelled" && state !== "Terminated";
   }
 }

--- a/src/payment/agreement_payment_process.ts
+++ b/src/payment/agreement_payment_process.ts
@@ -187,14 +187,17 @@ export class AgreementPaymentProcess {
       await this.paymentModule.rejectDebitNote(debitNote, rejectMessage);
       this.logger.warn(`DebitNote rejected`, { reason: rejectMessage });
     } catch (error) {
-      const message = getMessageFromApiError(error);
-      throw new GolemPaymentError(
-        `Unable to reject debit note ${debitNote.id}. ${message}`,
-        PaymentErrorCode.DebitNoteRejectionFailed,
-        undefined,
-        debitNote.provider,
-        error,
-      );
+      this.logger.warn(`DebitNote rejected`, { reason: rejectMessage });
+      // TODO: this endpoint is not implemented in Yagna, it always responds 501:NotImplemented.
+      // Until it is implemented ny Yagna, it only logs as a warning
+      // const message = getMessageFromApiError(error);
+      // throw new GolemPaymentError(
+      //   `Unable to reject debit note ${debitNote.id}. ${message}`,
+      //   PaymentErrorCode.DebitNoteRejectionFailed,
+      //   undefined,
+      //   debitNote.provider,
+      //   error,
+      // );
     }
   }
 
@@ -282,14 +285,17 @@ export class AgreementPaymentProcess {
       await this.paymentModule.rejectInvoice(invoice, message);
       this.logger.warn(`Invoice rejected`, { reason: message });
     } catch (error) {
-      const message = getMessageFromApiError(error);
-      throw new GolemPaymentError(
-        `Unable to reject invoice ${invoice.id} ${message}`,
-        PaymentErrorCode.InvoiceRejectionFailed,
-        undefined,
-        invoice.provider,
-        error,
-      );
+      this.logger.warn(`Invoice rejected`, { reason: message });
+      // TODO: this endpoint is not implemented in Yagna, it always responds 501:NotImplemented.
+      // Until it is implemented ny Yagna, it only logs as a warning
+      // const message = getMessageFromApiError(error);
+      // throw new GolemPaymentError(
+      //   `Unable to reject invoice ${invoice.id} ${message}`,
+      //   PaymentErrorCode.InvoiceRejectionFailed,
+      //   undefined,
+      //   invoice.provider,
+      //   error,
+      // );
     }
   }
 

--- a/src/payment/agreement_payment_process.ts
+++ b/src/payment/agreement_payment_process.ts
@@ -185,19 +185,15 @@ export class AgreementPaymentProcess {
   private async rejectDebitNote(debitNote: DebitNote, rejectionReason: RejectionReason, rejectMessage: string) {
     try {
       await this.paymentModule.rejectDebitNote(debitNote, rejectMessage);
-      this.logger.warn(`DebitNote rejected`, { reason: rejectMessage });
     } catch (error) {
-      this.logger.warn(`DebitNote rejected`, { reason: rejectMessage });
-      // TODO: this endpoint is not implemented in Yagna, it always responds 501:NotImplemented.
-      // Until it is implemented by Yagna, it only logs as a warning
-      // const message = getMessageFromApiError(error);
-      // throw new GolemPaymentError(
-      //   `Unable to reject debit note ${debitNote.id}. ${message}`,
-      //   PaymentErrorCode.DebitNoteRejectionFailed,
-      //   undefined,
-      //   debitNote.provider,
-      //   error,
-      // );
+      const message = getMessageFromApiError(error);
+      throw new GolemPaymentError(
+        `Unable to reject debit note ${debitNote.id}. ${message}`,
+        PaymentErrorCode.DebitNoteRejectionFailed,
+        undefined,
+        debitNote.provider,
+        error,
+      );
     }
   }
 
@@ -285,17 +281,14 @@ export class AgreementPaymentProcess {
       await this.paymentModule.rejectInvoice(invoice, message);
       this.logger.warn(`Invoice rejected`, { reason: message });
     } catch (error) {
-      this.logger.warn(`Invoice rejected`, { reason: message });
-      // TODO: this endpoint is not implemented in Yagna, it always responds 501:NotImplemented.
-      // Until it is implemented by Yagna, it only logs as a warning
-      // const message = getMessageFromApiError(error);
-      // throw new GolemPaymentError(
-      //   `Unable to reject invoice ${invoice.id} ${message}`,
-      //   PaymentErrorCode.InvoiceRejectionFailed,
-      //   undefined,
-      //   invoice.provider,
-      //   error,
-      // );
+      const message = getMessageFromApiError(error);
+      throw new GolemPaymentError(
+        `Unable to reject invoice ${invoice.id} ${message}`,
+        PaymentErrorCode.InvoiceRejectionFailed,
+        undefined,
+        invoice.provider,
+        error,
+      );
     }
   }
 

--- a/src/payment/agreement_payment_process.ts
+++ b/src/payment/agreement_payment_process.ts
@@ -189,7 +189,7 @@ export class AgreementPaymentProcess {
     } catch (error) {
       this.logger.warn(`DebitNote rejected`, { reason: rejectMessage });
       // TODO: this endpoint is not implemented in Yagna, it always responds 501:NotImplemented.
-      // Until it is implemented ny Yagna, it only logs as a warning
+      // Until it is implemented by Yagna, it only logs as a warning
       // const message = getMessageFromApiError(error);
       // throw new GolemPaymentError(
       //   `Unable to reject debit note ${debitNote.id}. ${message}`,
@@ -287,7 +287,7 @@ export class AgreementPaymentProcess {
     } catch (error) {
       this.logger.warn(`Invoice rejected`, { reason: message });
       // TODO: this endpoint is not implemented in Yagna, it always responds 501:NotImplemented.
-      // Until it is implemented ny Yagna, it only logs as a warning
+      // Until it is implemented by Yagna, it only logs as a warning
       // const message = getMessageFromApiError(error);
       // throw new GolemPaymentError(
       //   `Unable to reject invoice ${invoice.id} ${message}`,

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -210,7 +210,7 @@ export class PaymentModuleImpl implements PaymentModule {
       this.events.emit("debitNoteRejected", rejectedDebitNote);
       return rejectedDebitNote;
     } catch (error) {
-      this.events.emit("errorAcceptingDebitNote", debitNote, error);
+      this.events.emit("errorRejectingDebitNote", debitNote, error);
       throw error;
     }
   }

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -15,6 +15,7 @@ import { PayerDetails } from "./PayerDetails";
 import { AgreementPaymentProcess, PaymentProcessOptions } from "./agreement_payment_process";
 import { Agreement } from "../market";
 import * as EnvUtils from "../shared/utils/env";
+import { GolemInternalError } from "../shared/error/golem-error";
 
 export interface PaymentModuleOptions {
   /**
@@ -205,14 +206,20 @@ export class PaymentModuleImpl implements PaymentModule {
 
   async rejectDebitNote(debitNote: DebitNote, reason: string): Promise<DebitNote> {
     this.logger.info("Rejecting debit note", { id: debitNote.id, reason });
-    try {
-      const rejectedDebitNote = await this.paymentApi.rejectDebitNote(debitNote, reason);
-      this.events.emit("debitNoteRejected", rejectedDebitNote);
-      return rejectedDebitNote;
-    } catch (error) {
-      this.events.emit("errorRejectingDebitNote", debitNote, error);
-      throw error;
-    }
+    // TODO: this is not supported by PaymnetAdapter
+    const message = "Unable to send debitNote rejection to provider. This feature is not yet supported.";
+    this.logger.warn(message);
+    this.events.emit("errorRejectingDebitNote", debitNote, new GolemInternalError(message));
+    return debitNote;
+    // this.logger.debug("Rejecting debit note", { id: debitNote.id, reason });
+    // try {
+    //   const rejectedDebitNote = await this.paymentApi.rejectDebitNote(debitNote, reason);
+    //   this.events.emit("debitNoteRejected", rejectedDebitNote);
+    //   return rejectedDebitNote;
+    // } catch (error) {
+    //   this.events.emit("errorRejectingDebitNote", debitNote, error);
+    //   throw error;
+    // }
   }
 
   /**

--- a/src/shared/yagna/adapters/payment-api-adapter.ts
+++ b/src/shared/yagna/adapters/payment-api-adapter.ts
@@ -134,13 +134,15 @@ export class PaymentApiAdapter implements IPaymentApi {
     }
   }
 
-  async rejectDebitNote(debitNote: DebitNote, reason: string): Promise<DebitNote> {
+  async rejectDebitNote(debitNote: DebitNote): Promise<DebitNote> {
     try {
-      await this.yagna.payment.rejectDebitNote(debitNote.id, {
-        rejectionReason: "BAD_SERVICE",
-        totalAmountAccepted: "0.00",
-        message: reason,
-      });
+      // TODO: this endpoint is not implemented in Yagna, it always responds 501:NotImplemented.
+      // Reported in https://github.com/golemfactory/yagna/issues/1249
+      // await this.yagna.payment.rejectDebitNote(debitNote.id, {
+      //   rejectionReason: "BAD_SERVICE",
+      //   totalAmountAccepted: "0.00",
+      //   message: reason,
+      // });
 
       return this.debitNoteRepo.getById(debitNote.id);
     } catch (error) {
@@ -150,6 +152,7 @@ export class PaymentApiAdapter implements IPaymentApi {
         PaymentErrorCode.DebitNoteRejectionFailed,
         undefined,
         debitNote.provider,
+        error,
       );
     }
   }


### PR DESCRIPTION
If the agreement is terminated on the provider's side, we should not send a request to yagna for termination.

In addition, in the case of debitNote/Invoice rejection e.g. due to filters, we should not send a request to the endpoint reject - Yagna has not implemented this and always responds 501:NotImplented