### PR TITLE
feat: added ability to cancel lease processes

### DIFF
--- a/src/activity/activity.module.ts
+++ b/src/activity/activity.module.ts
@@ -248,10 +248,7 @@ export class ActivityModuleImpl implements ActivityModule {
                 "Initializing of the exe-unit has been aborted due to a timeout",
                 options.signalOrTimeout.reason,
               )
-            : new GolemAbortError(
-                "Initializing of the exe-unit has been aborted by a signal",
-                options.signalOrTimeout.reason,
-              );
+            : new GolemAbortError("Initializing of the exe-unit has been aborted", options.signalOrTimeout.reason);
         throw error;
       }
       throw error;

--- a/src/activity/activity.module.ts
+++ b/src/activity/activity.module.ts
@@ -7,7 +7,6 @@ import { WorkContext, WorkOptions } from "./work";
 import { ExeScriptExecutor, ExeScriptRequest, ExecutionOptions } from "./exe-script-executor";
 import { Observable, catchError, tap } from "rxjs";
 import { StreamingBatchEvent } from "./results";
-import { GolemAbortError, GolemTimeoutError } from "../shared/error/golem-error";
 
 export interface ActivityModule {
   events: EventEmitter<ActivityEvents>;
@@ -241,16 +240,6 @@ export class ActivityModuleImpl implements ActivityModule {
       return ctx;
     } catch (error) {
       this.events.emit("errorInitializingActivity", activity, error);
-      if (options?.signalOrTimeout instanceof AbortSignal && options.signalOrTimeout.aborted) {
-        const error =
-          options.signalOrTimeout.reason.name === "TimeoutError"
-            ? new GolemTimeoutError(
-                "Initializing of the exe-unit has been aborted due to a timeout",
-                options.signalOrTimeout.reason,
-              )
-            : new GolemAbortError("Initializing of the exe-unit has been aborted", options.signalOrTimeout.reason);
-        throw error;
-      }
       throw error;
     }
   }

--- a/src/activity/config.ts
+++ b/src/activity/config.ts
@@ -1,8 +1,6 @@
 import { ExecutionOptions } from "./exe-script-executor";
 
 const DEFAULTS = {
-  activityRequestTimeout: 10000,
-  activityExecuteTimeout: 1000 * 60 * 5, // 5 min,
   activityExeBatchResultPollIntervalSeconds: 5,
   activityExeBatchResultMaxRetries: 20,
 };
@@ -11,14 +9,10 @@ const DEFAULTS = {
  * @internal
  */
 export class ExecutionConfig {
-  public readonly activityRequestTimeout: number;
-  public readonly activityExecuteTimeout: number;
   public readonly activityExeBatchResultPollIntervalSeconds: number;
   public readonly activityExeBatchResultMaxRetries: number;
 
   constructor(options?: ExecutionOptions) {
-    this.activityRequestTimeout = options?.activityRequestTimeout || DEFAULTS.activityRequestTimeout;
-    this.activityExecuteTimeout = options?.activityExecuteTimeout || DEFAULTS.activityExecuteTimeout;
     this.activityExeBatchResultMaxRetries =
       options?.activityExeBatchResultMaxRetries || DEFAULTS.activityExeBatchResultMaxRetries;
     this.activityExeBatchResultPollIntervalSeconds =

--- a/src/activity/exe-script-executor.test.ts
+++ b/src/activity/exe-script-executor.test.ts
@@ -248,12 +248,10 @@ describe("ExeScriptExecutor", () => {
       const script = Script.create([command1, command2, command3, command4, command5, command6]);
       await script.before();
       const results = await executor.execute(script.getExeScriptRequest(), undefined, undefined);
-      ac.abort(new Error("test reson"));
+      ac.abort();
       return new Promise<void>((res) => {
         results.on("error", (error) => {
-          expect(error).toMatchError(
-            new GolemAbortError(`Processing of batch execution has been aborted`, new Error("test reson")),
-          );
+          expect(error).toEqual(new GolemAbortError(`Processing of script execution has been aborted`));
           return res();
         });
         results.on("data", () => null);
@@ -282,12 +280,10 @@ describe("ExeScriptExecutor", () => {
       const script = Script.create([command1, command2, command3, command4]);
       await script.before();
       const results = await executor.execute(script.getExeScriptRequest(), true, undefined);
-      ac.abort(new Error("test reson"));
+      ac.abort();
       return new Promise<void>((res) => {
         results.on("error", (error) => {
-          expect(error).toMatchError(
-            new GolemAbortError(`Processing of batch execution has been aborted`, new Error("test reson")),
-          );
+          expect(error).toEqual(new GolemAbortError(`Processing of script execution has been aborted`));
           return res();
         });
         results.on("data", () => null);

--- a/src/activity/exe-script-executor.ts
+++ b/src/activity/exe-script-executor.ts
@@ -56,6 +56,7 @@ export class ExeScriptExecutor {
   ): Promise<Readable> {
     let batchId: string, batchSize: number;
     const abortController = new AbortController();
+    // abort execution in case of cancellation by global signal or by local signal (from parameter)
     this.abortSignal.addEventListener("abort", () => abortController.abort(this.abortSignal.reason));
     if (signalOrTimeout) {
       const abortSignal = createAbortSignalFromTimeout(signalOrTimeout);

--- a/src/activity/exe-script-executor.ts
+++ b/src/activity/exe-script-executor.ts
@@ -79,8 +79,11 @@ export class ExeScriptExecutor {
         reason: message,
       });
 
+      if (this.abortSignal.aborted) {
+        throw new GolemAbortError("Executions of script has been aborted", this.abortSignal.reason);
+      }
       throw new GolemWorkError(
-        `Unable to execute script ${message}`,
+        `Unable to execute script. ${message}`,
         WorkErrorCode.ScriptExecutionFailed,
         this.activity.agreement,
         this.activity,

--- a/src/activity/exe-script-executor.ts
+++ b/src/activity/exe-script-executor.ts
@@ -63,11 +63,11 @@ export class ExeScriptExecutor {
     }
 
     try {
-      this.abortSignal.throwIfAborted();
+      abortController.signal.throwIfAborted();
       batchId = await this.send(script);
       batchSize = JSON.parse(script.text).length;
 
-      this.abortSignal.throwIfAborted();
+      abortController.signal.throwIfAborted();
       this.logger.debug(`Script sent.`, { batchId });
 
       return stream
@@ -80,7 +80,7 @@ export class ExeScriptExecutor {
         reason: message,
       });
 
-      if (this.abortSignal.aborted) {
+      if (abortController.signal.aborted) {
         throw new GolemAbortError("Executions of script has been aborted", this.abortSignal.reason);
       }
       throw new GolemWorkError(

--- a/src/activity/work/work.ts
+++ b/src/activity/work/work.ts
@@ -18,7 +18,7 @@ import { Batch } from "./batch";
 import { NetworkNode } from "../../network";
 import { RemoteProcess } from "./process";
 import { GolemWorkError, WorkErrorCode } from "./error";
-import { GolemConfigError, GolemTimeoutError } from "../../shared/error/golem-error";
+import { GolemAbortError, GolemConfigError, GolemTimeoutError } from "../../shared/error/golem-error";
 import { Agreement, ProviderInfo } from "../../market/agreement";
 import { TcpProxy } from "../../network/tcpProxy";
 import { ExecutionOptions, ExeScriptExecutor } from "../exe-script-executor";
@@ -93,7 +93,7 @@ export class WorkContext {
 
   private async fetchState(): Promise<ActivityStateEnum> {
     if (this.abortSignal.aborted) {
-      return ActivityStateEnum.Unknown;
+      throw new GolemAbortError("ExeUnit has been aborted");
     }
     return this.activityModule
       .refreshActivity(this.activity)
@@ -162,7 +162,7 @@ export class WorkContext {
           if (this.abortSignal.aborted) {
             const message = "Initializing of activity has been aborted";
             this.logger.warn(message, { activityId: this.activity.id, reason: this.abortSignal.reason });
-            return;
+            throw new GolemAbortError(message, this.abortSignal.reason);
           }
           if (error instanceof GolemWorkError) {
             throw error;

--- a/src/activity/work/work.ts
+++ b/src/activity/work/work.ts
@@ -159,7 +159,8 @@ export class WorkContext {
       ])
         .catch((error) => {
           if (this.abortSignal.aborted) {
-            this.logger.warn("Initializing of activity has been aborted", { reason: this.abortSignal.reason });
+            const message = "Initializing of activity has been aborted";
+            this.logger.warn(message, { activityId: this.activity.id, reason: this.abortSignal.reason });
             return;
           }
           if (error instanceof GolemWorkError) {

--- a/src/activity/work/work.ts
+++ b/src/activity/work/work.ts
@@ -43,7 +43,8 @@ export interface WorkOptions {
 }
 
 export interface CommandOptions {
-  timeout?: number;
+  signalOrTimeout?: number | AbortSignal;
+  maxRetries?: number;
   env?: object;
   capture?: Capture;
 }
@@ -267,7 +268,7 @@ export class WorkContext {
     // In this case, the script consists only of one run command,
     // so we skip the execution of script.before and script.after
     const streamOfActivityResults = await this.executor
-      .execute(script.getExeScriptRequest(), true, options?.timeout)
+      .execute(script.getExeScriptRequest(), true, options?.signalOrTimeout, options?.maxRetries)
       .catch((e) => {
         throw new GolemWorkError(
           `Script execution failed for command: ${JSON.stringify(run.toJson())}. ${
@@ -414,7 +415,12 @@ export class WorkContext {
     await sleep(100, true);
 
     // Send script.
-    const results = await this.executor.execute(script.getExeScriptRequest(), false, options?.timeout);
+    const results = await this.executor.execute(
+      script.getExeScriptRequest(),
+      false,
+      options?.signalOrTimeout,
+      options?.maxRetries,
+    );
 
     // Process result.
     let allResults: Result<T>[] = [];

--- a/src/golem-network/golem-network.ts
+++ b/src/golem-network/golem-network.ts
@@ -331,7 +331,7 @@ export class GolemNetwork {
    *
    * @param order
    */
-  async oneOf(order: MarketOrderSpec): Promise<LeaseProcess> {
+  async oneOf(order: MarketOrderSpec, signalOrTimeout?: number | AbortSignal): Promise<LeaseProcess> {
     const proposalPool = new DraftOfferProposalPool({
       logger: this.logger,
       validateProposal: order.market.proposalFilter,
@@ -354,9 +354,13 @@ export class GolemNetwork {
 
     const proposalSubscription = proposalPool.readFrom(draftProposal$);
 
-    const agreement = await this.market.signAgreementFromPool(proposalPool, {
-      expirationSec: order.market.rentHours * 60 * 60,
-    });
+    const agreement = await this.market.signAgreementFromPool(
+      proposalPool,
+      {
+        expirationSec: order.market.rentHours * 60 * 60,
+      },
+      signalOrTimeout,
+    );
 
     const networkNode = order.network
       ? await this.network.createNetworkNode(order.network, agreement.getProviderInfo().id)
@@ -366,6 +370,7 @@ export class GolemNetwork {
       payment: order.payment,
       activity: order.activity,
       networkNode,
+      signalOrTimeout,
     });
 
     // We managed to create the activity, no need to look for more agreement candidates

--- a/src/golem-network/golem-network.ts
+++ b/src/golem-network/golem-network.ts
@@ -330,6 +330,7 @@ export class GolemNetwork {
    * ```
    *
    * @param order
+   * @param signalOrTimeout - the timeout in milliseconds or an AbortSignal that will be used to cancel the lease request
    */
   async oneOf(order: MarketOrderSpec, signalOrTimeout?: number | AbortSignal): Promise<LeaseProcess> {
     const proposalPool = new DraftOfferProposalPool({

--- a/src/golem-network/golem-network.ts
+++ b/src/golem-network/golem-network.ts
@@ -370,7 +370,6 @@ export class GolemNetwork {
       payment: order.payment,
       activity: order.activity,
       networkNode,
-      signalOrTimeout,
     });
 
     // We managed to create the activity, no need to look for more agreement candidates

--- a/src/lease-process/lease-process-pool.test.ts
+++ b/src/lease-process/lease-process-pool.test.ts
@@ -57,13 +57,13 @@ describe("LeaseProcessPool", () => {
       await pool.ready();
 
       expect(pool.getAvailableSize()).toBe(5);
-      verify(marketModule.signAgreementFromPool(_, _)).times(5);
+      verify(marketModule.signAgreementFromPool(_, _, _)).times(5);
     });
     it("retries on error", async () => {
       when(leaseModule.createLease(_, _, _)).thenCall(() => ({}) as LeaseProcess);
 
       const fakeAgreement = {} as Agreement;
-      when(marketModule.signAgreementFromPool(_, _))
+      when(marketModule.signAgreementFromPool(_, _, _))
         .thenResolve(fakeAgreement)
         .thenReject(new Error("Failed to propose agreement"))
         .thenResolve(fakeAgreement)
@@ -75,7 +75,7 @@ describe("LeaseProcessPool", () => {
       await pool.ready();
 
       expect(pool.getAvailableSize()).toBe(3);
-      verify(marketModule.signAgreementFromPool(_, _)).times(5);
+      verify(marketModule.signAgreementFromPool(_, _, _)).times(5);
     });
     it("stops retrying after abort signal is triggered", async () => {
       const pool = getLeasePool({ min: 3 });

--- a/src/lease-process/lease-process-pool.ts
+++ b/src/lease-process/lease-process-pool.ts
@@ -114,7 +114,6 @@ export class LeaseProcessPool {
       const leaseProcess = this.leaseModule.createLease(agreement, this.allocation, {
         networkNode,
         ...this.leaseProcessOptions,
-        signalOrTimeout,
       });
       this.events.emit("created", agreement);
       return leaseProcess;
@@ -230,7 +229,7 @@ export class LeaseProcessPool {
   async destroy(leaseProcess: LeaseProcess): Promise<void> {
     try {
       this.borrowed.delete(leaseProcess);
-      this.logger.debug("Destroying lease process from the pool", { agreementId: leaseProcess.agreement.id });
+      this.logger.info("Destroying lease process from the pool", { agreementId: leaseProcess.agreement.id });
       await Promise.all([leaseProcess.finalize(), this.removeNetworkNode(leaseProcess)]);
       this.events.emit("destroyed", leaseProcess.agreement);
     } catch (error) {

--- a/src/market/draft-offer-proposal-pool.test.ts
+++ b/src/market/draft-offer-proposal-pool.test.ts
@@ -1,6 +1,7 @@
 import { DraftOfferProposalPool } from "./draft-offer-proposal-pool";
 import { instance, mock, when } from "@johanblumenberg/ts-mockito";
 import { OfferProposal } from "./index";
+import { GolemAbortError, GolemTimeoutError } from "../shared/error/golem-error";
 
 describe("Draft Offer Proposal Pool", () => {
   // GIVEN
@@ -105,6 +106,20 @@ describe("Draft Offer Proposal Pool", () => {
         const a = await pool.acquire();
 
         expect(a).toBe(proposal2);
+      });
+    });
+    describe("Negative cases", () => {
+      it("should abort the acquiring proposal by timeout", async () => {
+        const pool = new DraftOfferProposalPool();
+        await expect(pool.acquire(1)).rejects.toThrow(new GolemTimeoutError("Could not provide any proposal in time"));
+      });
+      it("should abort the acquiring proposal by signal", async () => {
+        const pool = new DraftOfferProposalPool();
+        const ac = new AbortController();
+        ac.abort();
+        await expect(pool.acquire(ac.signal)).rejects.toThrow(
+          new GolemAbortError("The acquiring of proposals has been aborted"),
+        );
       });
     });
   });

--- a/src/market/draft-offer-proposal-pool.ts
+++ b/src/market/draft-offer-proposal-pool.ts
@@ -105,7 +105,7 @@ export class DraftOfferProposalPool {
   }
 
   /**
-   * Attempts to obtain a single proposal from the poolonds.
+   * Attempts to obtain a single proposal from the pool
    * @param signalOrTimeout - the timeout in milliseconds or an AbortSignal that will be used to cancel the acquiring
    */
   public acquire(signalOrTimeout?: number | AbortSignal): Promise<OfferProposal> {

--- a/src/market/draft-offer-proposal-pool.ts
+++ b/src/market/draft-offer-proposal-pool.ts
@@ -106,7 +106,7 @@ export class DraftOfferProposalPool {
 
   /**
    * Attempts to obtain a single proposal from the poolonds.
-   * @param TODO
+   * @param signalOrTimeout - the timeout in milliseconds or an AbortSignal that will be used to cancel the acquiring
    */
   public acquire(signalOrTimeout?: number | AbortSignal): Promise<OfferProposal> {
     const signal = createAbortSignalFromTimeout(signalOrTimeout);
@@ -117,7 +117,7 @@ export class DraftOfferProposalPool {
         if (signal.aborted) {
           throw signal.reason.name === "TimeoutError"
             ? new GolemTimeoutError("Could not provide any proposal in time")
-            : new GolemAbortError("The acquiring of proposals has been interrupted", signal.reason);
+            : new GolemAbortError("The acquiring of proposals has been aborted", signal.reason);
         }
         // Try to get one
         proposal = this.available.size > 0 ? this.selectProposal([...this.available]) : null;

--- a/src/market/market.module.test.ts
+++ b/src/market/market.module.test.ts
@@ -462,7 +462,7 @@ describe("Market module", () => {
       const marketSpy = spy(marketModule);
 
       await expect(marketModule.signAgreementFromPool(instance(mockPool), {}, ac.signal)).rejects.toMatchError(
-        new GolemAbortError("The signing of the agreement has been interrupted", error),
+        new GolemAbortError("The signing of the agreement has been aborted", error),
       );
 
       verify(mockPool.acquire(_)).once();
@@ -474,7 +474,7 @@ describe("Market module", () => {
       const mockPool = mock(DraftOfferProposalPool);
       const signal = AbortSignal.abort();
       await expect(marketModule.signAgreementFromPool(instance(mockPool), {}, signal)).rejects.toThrow(
-        "The signing of the agreement has been interrupted",
+        "The signing of the agreement has been aborted",
       );
       verify(mockPool.acquire()).never();
     });

--- a/src/market/market.module.ts
+++ b/src/market/market.module.ts
@@ -483,7 +483,7 @@ export class MarketModuleImpl implements MarketModule {
         if (signal.aborted) {
           throw signal.reason.name === "TimeoutError"
             ? new GolemTimeoutError("Could not sign any agreement in time")
-            : new GolemAbortError("The signing of the agreement has been interrupted", error);
+            : new GolemAbortError("The signing of the agreement has been aborted", error);
         }
         throw error;
       }

--- a/src/market/market.module.ts
+++ b/src/market/market.module.ts
@@ -473,7 +473,7 @@ export class MarketModuleImpl implements MarketModule {
     const getProposal = async () => {
       try {
         signal.throwIfAborted();
-        const proposal = await draftProposalPool.acquire(signalOrTimeout);
+        const proposal = await draftProposalPool.acquire(signal);
         if (signal.aborted) {
           await draftProposalPool.release(proposal);
           signal.throwIfAborted();

--- a/tests/e2e/leaseProcessPool.spec.ts
+++ b/tests/e2e/leaseProcessPool.spec.ts
@@ -1,6 +1,5 @@
 import { Subscription } from "rxjs";
 import { Allocation, DraftOfferProposalPool, GolemAbortError, GolemNetwork } from "../../src";
-import exp from "node:constants";
 
 describe("LeaseProcessPool", () => {
   const glm = new GolemNetwork();

--- a/tests/e2e/leaseProcessPool.spec.ts
+++ b/tests/e2e/leaseProcessPool.spec.ts
@@ -188,6 +188,7 @@ describe("LeaseProcessPool", () => {
   });
 
   it("should finalize the lease process during execution", async () => {
+    expect.assertions(1);
     const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
     const leaseProcess = await pool.acquire();
     const exe = await leaseProcess.getExeUnit();

--- a/tests/e2e/leaseProcessPool.spec.ts
+++ b/tests/e2e/leaseProcessPool.spec.ts
@@ -167,17 +167,31 @@ describe("LeaseProcessPool", () => {
     await expect(pool.acquire(abortControler.signal)).rejects.toThrow("The signing of the agreement has been aborted");
   });
 
-  it("should finalize lease process during execution", async () => {
+  it("should abort acquiring lease process by timeout", async () => {
+    const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
+    await expect(pool.acquire(1_000)).rejects.toThrow("Could not sign any agreement in time");
+  });
+
+  it("should finalize the lease process during execution", async () => {
     const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
     const leaseProcess = await pool.acquire();
     const exe = await leaseProcess.getExeUnit();
-    setTimeout(() => leaseProcess.finalize(), 8_000);
-    await expect(exe.run("sleep 10 && echo Hello World")).rejects.toThrow(
-      new GolemAbortError("Processing of script execution has been aborted"),
-    );
-    await pool.drainAndClear();
     return new Promise(async (res) => {
       leaseProcess.events.on("finalized", async () => res(true));
+      setTimeout(() => leaseProcess.finalize(), 8_000);
+      await expect(exe.run("sleep 10 && echo Hello World")).rejects.toThrow(
+        new GolemAbortError("Processing of script execution has been aborted"),
+      );
     });
+  });
+
+  it("should throw error while executing script on a finalized lease process", async () => {
+    const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
+    const leaseProcess = await pool.acquire();
+    const exe = await leaseProcess.getExeUnit();
+    await leaseProcess.finalize();
+    await expect(exe.run("echo Hello World")).rejects.toThrow(
+      new GolemAbortError("Executions of script has been aborted"),
+    );
   });
 });

--- a/tests/e2e/leaseProcessPool.spec.ts
+++ b/tests/e2e/leaseProcessPool.spec.ts
@@ -179,18 +179,8 @@ describe("LeaseProcessPool", () => {
       leaseProcess.events.on("finalized", async () => res(true));
       setTimeout(() => leaseProcess.finalize(), 8_000);
       await expect(exe.run("sleep 10 && echo Hello World")).rejects.toThrow(
-        new GolemAbortError("Processing of script execution has been aborted"),
+        new GolemAbortError("Execution of script has been aborted"),
       );
     });
-  });
-
-  it("should throw error while executing script on a finalized lease process", async () => {
-    const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
-    const leaseProcess = await pool.acquire();
-    const exe = await leaseProcess.getExeUnit();
-    await leaseProcess.finalize();
-    await expect(exe.run("echo Hello World")).rejects.toThrow(
-      new GolemAbortError("Executions of script has been aborted"),
-    );
   });
 });

--- a/tests/e2e/leaseProcessPool.spec.ts
+++ b/tests/e2e/leaseProcessPool.spec.ts
@@ -1,5 +1,5 @@
 import { Subscription } from "rxjs";
-import { Allocation, DraftOfferProposalPool, GolemNetwork } from "../../src";
+import { Allocation, DraftOfferProposalPool, GolemAbortError, GolemNetwork } from "../../src";
 
 describe("LeaseProcessPool", () => {
   const glm = new GolemNetwork();
@@ -157,5 +157,48 @@ describe("LeaseProcessPool", () => {
     await pool.destroy(leaseProcess2);
     await pool.drainAndClear();
     await glm.network.removeNetwork(network);
+  });
+
+  it("should abort lease process by abort call", async () => {
+    const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
+    const leaseProcess = await pool.acquire();
+    return new Promise(async (res) => {
+      leaseProcess.events.on("finalized", async () => res(true));
+      leaseProcess.abort("test reason");
+    });
+  });
+
+  it("should abort lease process during execution by abort call", async () => {
+    const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
+    const leaseProcess = await pool.acquire();
+    const exe = await leaseProcess.getExeUnit();
+    setTimeout(() => leaseProcess.abort(), 8_000);
+    await expect(exe.run("sleep 10 && echo Hello World")).rejects.toThrow(
+      new GolemAbortError("Processing of batch execution has been aborted"),
+    );
+    await pool.drainAndClear();
+  });
+
+  it("should abort lease during execution process by signal", async () => {
+    const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
+    const ac = new AbortController();
+    const leaseProcess = await pool.acquire(ac.signal);
+    const exe = await leaseProcess.getExeUnit();
+    setTimeout(() => ac.abort(), 8_000);
+    await expect(exe.run("sleep 10 && echo Hello World")).rejects.toThrow(
+      new GolemAbortError("Processing of batch execution has been aborted"),
+    );
+    await pool.drainAndClear();
+  });
+
+  it("should abort lease during execution process by timeout", async () => {
+    const pool = glm.lease.createLeaseProcessPool(proposalPool, allocation, { replicas: 1 });
+    const ac = new AbortController();
+    const leaseProcess = await pool.acquire(8_000);
+    const exe = await leaseProcess.getExeUnit();
+    await expect(exe.run("sleep 10 && echo Hello World")).rejects.toThrow(
+      new GolemAbortError("Processing of batch execution has been aborted"),
+    );
+    await pool.drainAndClear();
   });
 });

--- a/tests/unit/work.test.ts
+++ b/tests/unit/work.test.ts
@@ -14,7 +14,6 @@ import {
 } from "../../src";
 import { _, anyOfClass, anything, imock, instance, mock, reset, verify, when } from "@johanblumenberg/ts-mockito";
 import { buildExecutorResults, buildExeScriptErrorResult, buildExeScriptSuccessResult } from "./helpers";
-import { IPv4 } from "ip-num";
 import { StorageProviderDataCallback } from "../../src/shared/storage/provider";
 import { ActivityApi } from "ya-ts-client";
 import { ExeScriptExecutor } from "../../src/activity/exe-script-executor";
@@ -55,7 +54,7 @@ describe("Work Context", () => {
 
   describe("Executing", () => {
     it("should execute run command with a single parameter", async () => {
-      when(mockExecutor.execute(_, _, _)).thenResolve(
+      when(mockExecutor.execute(_, _, _, _)).thenResolve(
         buildExecutorResults([
           {
             index: 0,
@@ -75,7 +74,7 @@ describe("Work Context", () => {
     });
 
     it("should execute run command with multiple parameters", async () => {
-      when(mockExecutor.execute(_, _, _)).thenResolve(
+      when(mockExecutor.execute(_, _, _, _)).thenResolve(
         buildExecutorResults([
           {
             index: 0,
@@ -99,7 +98,7 @@ describe("Work Context", () => {
       it("should execute upload file command", async () => {
         const worker = async (ctx: WorkContext) => ctx.uploadFile("./file.txt", "/golem/file.txt");
 
-        when(mockExecutor.execute(_, _, _)).thenResolve(
+        when(mockExecutor.execute(_, _, _, _)).thenResolve(
           buildExecutorResults([
             {
               index: 0,
@@ -123,7 +122,7 @@ describe("Work Context", () => {
       it("should execute upload json command", async () => {
         const worker = async (ctx: WorkContext) => ctx.uploadJson({ test: true }, "/golem/file.txt");
 
-        when(mockExecutor.execute(_, _, _)).thenResolve(
+        when(mockExecutor.execute(_, _, _, _)).thenResolve(
           buildExecutorResults([
             {
               index: 0,
@@ -150,7 +149,7 @@ describe("Work Context", () => {
       it("should execute download file command", async () => {
         const worker = async (ctx: WorkContext) => ctx.downloadFile("/golem/file.txt", "./file.txt");
 
-        when(mockExecutor.execute(_, _, _)).thenResolve(
+        when(mockExecutor.execute(_, _, _, _)).thenResolve(
           buildExecutorResults([
             {
               index: 0,
@@ -178,7 +177,7 @@ describe("Work Context", () => {
         const jsonStr = JSON.stringify(json);
         const encoded = new TextEncoder().encode(jsonStr);
 
-        when(mockExecutor.execute(_, _, _)).thenResolve(
+        when(mockExecutor.execute(_, _, _, _)).thenResolve(
           buildExecutorResults([
             {
               index: 0,
@@ -211,7 +210,7 @@ describe("Work Context", () => {
 
         when(mockStorageProvider.receiveData(anything())).thenResolve(data.toString());
 
-        when(mockExecutor.execute(_, _, _)).thenResolve(
+        when(mockExecutor.execute(_, _, _, _)).thenResolve(
           buildExecutorResults([
             {
               index: 0,
@@ -248,7 +247,7 @@ describe("Work Context", () => {
   describe("Exec and stream", () => {
     it("should execute runAndStream command", async () => {
       const ctx = new WorkContext(instance(mockActivity), instance(mockActivityModule));
-      when(mockExecutor.execute(_, _, _)).thenResolve(
+      when(mockExecutor.execute(_, _, _, _)).thenResolve(
         buildExecutorResults([
           {
             index: 0,
@@ -269,7 +268,7 @@ describe("Work Context", () => {
     it("should execute transfer command", async () => {
       const ctx = new WorkContext(instance(mockActivity), instance(mockActivityModule));
 
-      when(mockExecutor.execute(_, _, _)).thenResolve(
+      when(mockExecutor.execute(_, _, _, _)).thenResolve(
         buildExecutorResults([
           {
             index: 0,
@@ -425,7 +424,7 @@ describe("Work Context", () => {
 
       const eventDate = new Date().toISOString();
 
-      when(mockExecutor.execute(_, _, _)).thenResolve(
+      when(mockExecutor.execute(_, _, _, _)).thenResolve(
         buildExecutorResults([
           {
             index: 0,


### PR DESCRIPTION
This PR includes:
 - removed the default timeout in draft-proposal-pool, instead added the `signalOrTimeout` parameter in the acquire method
 - added `signalOrTimeout` parameter to `oneOf` in golem-network
 - added `signalOrTimeout` parameter to `acquire` in lease-proposal-pool
 - changed `timeout` to `signalOrTimeout` parameter in `CommandOptions` in work-context
 - added `signalOrTimeout` parameter to `signAgreementFromPool` in market-module
 - removed `activityExecutionTimeout`  and `timeout` param in `execute` in exe-script-executor, instead added `signalOrTimeout` param in constructor (to cancel all executions) and in `execute` method (to cancel single execution)