### PR TITLE
fix(market): fixed demand refresh logic that produced unusable counte…

### DIFF
--- a/examples/advanced/reuse-allocation.ts
+++ b/examples/advanced/reuse-allocation.ts
@@ -4,7 +4,16 @@
  */
 import { MarketOrderSpec, GolemNetwork } from "@golem-sdk/golem-js";
 import { pinoPrettyLogger } from "@golem-sdk/pino-logger";
+
 (async () => {
+  const ALLOCATION_DURATION_HOURS = 1;
+  const RENTAL_DURATION_HOURS = 0.5;
+
+  console.assert(
+    ALLOCATION_DURATION_HOURS > RENTAL_DURATION_HOURS,
+    "Always create allocations that will live longer than the planned rental duration",
+  );
+
   const glm = new GolemNetwork({
     logger: pinoPrettyLogger({
       level: "info",
@@ -16,7 +25,7 @@ import { pinoPrettyLogger } from "@golem-sdk/pino-logger";
 
     const allocation = await glm.payment.createAllocation({
       budget: 1,
-      expirationSec: 3600,
+      expirationSec: ALLOCATION_DURATION_HOURS * 60 * 60,
     });
 
     const firstOrder: MarketOrderSpec = {
@@ -24,7 +33,7 @@ import { pinoPrettyLogger } from "@golem-sdk/pino-logger";
         workload: { imageTag: "golem/alpine:latest" },
       },
       market: {
-        rentHours: 0.5,
+        rentHours: RENTAL_DURATION_HOURS,
         pricing: {
           model: "burn-rate",
           avgGlmPerHour: 0.5,
@@ -40,7 +49,7 @@ import { pinoPrettyLogger } from "@golem-sdk/pino-logger";
         workload: { imageTag: "golem/alpine:latest" },
       },
       market: {
-        rentHours: 0.5,
+        rentHours: RENTAL_DURATION_HOURS,
         pricing: {
           model: "burn-rate",
           avgGlmPerHour: 0.5,

--- a/examples/advanced/step-by-step.ts
+++ b/examples/advanced/step-by-step.ts
@@ -24,11 +24,20 @@ import { filter, map, switchMap, take } from "rxjs";
     logger,
   });
 
+  const RENTAL_DURATION_HOURS = 5 / 60;
+  const ALLOCATION_DURATION_HOURS = RENTAL_DURATION_HOURS + 0.25;
+
+  console.assert(
+    ALLOCATION_DURATION_HOURS > RENTAL_DURATION_HOURS,
+    "Always create allocations that will live longer than the planned rental duration",
+  );
+
   let allocation: Allocation | undefined;
   try {
     await glm.connect();
 
     // Define the order that we're going to place on the market
+
     const order: MarketOrderSpec = {
       demand: {
         workload: {
@@ -36,11 +45,10 @@ import { filter, map, switchMap, take } from "rxjs";
           minCpuCores: 1,
           minMemGib: 2,
         },
-        expirationSec: 30 * 60,
       },
       market: {
         // We're only going to rent the provider for 5 minutes max
-        rentHours: 5 / 60,
+        rentHours: RENTAL_DURATION_HOURS,
         pricing: {
           model: "linear",
           maxStartPrice: 1,
@@ -51,13 +59,14 @@ import { filter, map, switchMap, take } from "rxjs";
     };
     // Allocate funds to cover the order, we will only pay for the actual usage
     // so any unused funds will be returned to us at the end
+
     allocation = await glm.payment.createAllocation({
       budget: glm.market.estimateBudget({ order, maxAgreements: 1 }),
-      expirationSec: order.market.rentHours * 60 * 60,
+      expirationSec: ALLOCATION_DURATION_HOURS * 60 * 60,
     });
 
     // Convert the human-readable order to a protocol-level format that we will publish on the network
-    const demandSpecification = await glm.market.buildDemandDetails(order.demand, allocation);
+    const demandSpecification = await glm.market.buildDemandDetails(order.demand, order.market, allocation);
 
     // Publish the order on the market
     // This methods creates and observable that publishes the order and refreshes it every 30 minutes.

--- a/src/experimental/deployment/deployment.ts
+++ b/src/experimental/deployment/deployment.ts
@@ -153,7 +153,12 @@ export class Deployment {
         ? this.networks.get(pool.options?.deployment.network)
         : undefined;
 
-      const demandSpecification = await this.modules.market.buildDemandDetails(pool.options.demand, allocation);
+      const demandSpecification = await this.modules.market.buildDemandDetails(
+        pool.options.demand,
+        pool.options.market,
+        allocation,
+      );
+
       const proposalPool = new DraftOfferProposalPool({
         logger: this.logger,
         validateOfferProposal: pool.options.market.offerProposalFilter,

--- a/src/market/agreement/agreement.test.ts
+++ b/src/market/agreement/agreement.test.ts
@@ -33,7 +33,6 @@ const demand = new Demand(
       properties: [],
     },
     "erc20-holesky-tglm",
-    30 * 60,
   ),
 );
 

--- a/src/market/demand/demand.ts
+++ b/src/market/demand/demand.ts
@@ -82,7 +82,7 @@ export interface BasicDemandPropertyConfig {
   midAgreementPaymentTimeoutSec: number;
 }
 
-export type BuildDemandOptions = Partial<{
+export type OrderDemandOptions = Partial<{
   /** Demand properties related to the activities that will be executed on providers */
   workload: Partial<WorkloadDemandDirectorConfigOptions>;
   /** Demand properties that determine payment related terms & conditions of the agreement */
@@ -104,7 +104,6 @@ export class DemandSpecification {
     /** Represents the low level demand request body that will be used to subscribe for offers matching our "computational resource needs" */
     public readonly prototype: DemandBodyPrototype,
     public readonly paymentPlatform: string,
-    public readonly expirationSec: number,
   ) {}
 }
 

--- a/src/market/demand/directors/basic-demand-director-config.test.ts
+++ b/src/market/demand/directors/basic-demand-director-config.test.ts
@@ -1,12 +1,11 @@
 import { BasicDemandDirectorConfig } from "./basic-demand-director-config";
 
 describe("BasicDemandDirectorConfig", () => {
-  test("should throw user error if expiration option is invalid", () => {
-    expect(() => {
-      new BasicDemandDirectorConfig({
-        expirationSec: -3,
-        subnetTag: "public",
-      });
-    }).toThrow("The demand expiration time has to be a positive integer");
+  test("it sets the subnet tag property", () => {
+    const config = new BasicDemandDirectorConfig({
+      subnetTag: "public",
+    });
+
+    expect(config.subnetTag).toBe("public");
   });
 });

--- a/src/market/demand/directors/basic-demand-director-config.ts
+++ b/src/market/demand/directors/basic-demand-director-config.ts
@@ -1,28 +1,19 @@
 import { BaseConfig } from "./base-config";
-import { GolemConfigError } from "../../../shared/error/golem-error";
 import * as EnvUtils from "../../../shared/utils/env";
 
 export interface BasicDemandDirectorConfigOptions {
-  expirationSec: number;
+  /** Determines which subnet tag should be used for the offer/demand matching */
   subnetTag: string;
 }
 
 export class BasicDemandDirectorConfig extends BaseConfig implements BasicDemandDirectorConfigOptions {
-  public readonly expirationSec = 30 * 60; // 30 minutes
   public readonly subnetTag: string = EnvUtils.getYagnaSubnet();
 
   constructor(options?: Partial<BasicDemandDirectorConfigOptions>) {
     super();
 
-    if (options?.expirationSec) {
-      this.expirationSec = options.expirationSec;
-    }
     if (options?.subnetTag) {
       this.subnetTag = options.subnetTag;
-    }
-
-    if (!this.isPositiveInt(this.expirationSec)) {
-      throw new GolemConfigError("The demand expiration time has to be a positive integer");
     }
   }
 }

--- a/src/market/demand/directors/basic-demand-director.ts
+++ b/src/market/demand/directors/basic-demand-director.ts
@@ -8,7 +8,6 @@ export class BasicDemandDirector implements IDemandDirector {
   apply(builder: DemandBodyBuilder) {
     builder
       .addProperty("golem.srv.caps.multi-activity", true)
-      .addProperty("golem.srv.comp.expiration", Date.now() + this.config.expirationSec * 1000)
       .addProperty("golem.node.debug.subnet", this.config.subnetTag);
 
     builder

--- a/src/market/demand/directors/workload-demand-director-config.ts
+++ b/src/market/demand/directors/workload-demand-director-config.ts
@@ -1,11 +1,17 @@
 import { WorkloadDemandDirectorConfigOptions } from "../options";
 import { GolemConfigError } from "../../../shared/error/golem-error";
+import { BaseConfig } from "./base-config";
 
 export enum PackageFormat {
   GVMKitSquash = "gvmkit-squash",
 }
 
-export class WorkloadDemandDirectorConfig {
+type RequiredWorkloadDemandConfigOptions = {
+  /** Number of seconds after which the agreement resulting from this demand will no longer be valid */
+  expirationSec: number;
+};
+
+export class WorkloadDemandDirectorConfig extends BaseConfig {
   readonly packageFormat: string = PackageFormat.GVMKitSquash;
   readonly engine: string = "vm";
   readonly minMemGib: number = 0.5;
@@ -13,6 +19,9 @@ export class WorkloadDemandDirectorConfig {
   readonly minCpuThreads: number = 1;
   readonly minCpuCores: number = 1;
   readonly capabilities: string[] = [];
+
+  readonly expirationSec: number;
+
   readonly manifest?: string;
   readonly manifestSig?: string;
   readonly manifestSigAlgorithm?: string;
@@ -22,10 +31,12 @@ export class WorkloadDemandDirectorConfig {
   readonly imageTag?: string;
   readonly imageUrl?: string;
 
-  constructor(options?: Partial<WorkloadDemandDirectorConfigOptions>) {
-    if (options) {
-      Object.assign(this, options);
-    }
+  constructor(options: Partial<WorkloadDemandDirectorConfigOptions> & RequiredWorkloadDemandConfigOptions) {
+    super();
+
+    Object.assign(this, options);
+
+    this.expirationSec = options.expirationSec;
 
     if (!this.imageHash && !this.manifest && !this.imageTag && !this.imageUrl) {
       throw new GolemConfigError("You must define a package or manifest option");
@@ -33,6 +44,10 @@ export class WorkloadDemandDirectorConfig {
 
     if (this.imageUrl && !this.imageHash) {
       throw new GolemConfigError("If you provide an imageUrl, you must also provide it's SHA3-224 hash in imageHash");
+    }
+
+    if (!this.isPositiveInt(this.expirationSec)) {
+      throw new GolemConfigError("The expirationSec param has to be a positive integer");
     }
   }
 }

--- a/src/market/demand/directors/workload-demand-director.test.ts
+++ b/src/market/demand/directors/workload-demand-director.test.ts
@@ -9,6 +9,7 @@ describe("ActivityDemandDirector", () => {
     const director = new WorkloadDemandDirector(
       new WorkloadDemandDirectorConfig({
         imageHash: "529f7fdaf1cf46ce3126eb6bbcd3b213c314fe8fe884914f5d1106d4",
+        expirationSec: 600,
       }),
     );
     await director.apply(builder);
@@ -43,6 +44,7 @@ describe("ActivityDemandDirector", () => {
         manifestCert,
         manifestSigAlgorithm,
         capabilities,
+        expirationSec: 600,
       }),
     );
     await director.apply(builder);
@@ -70,5 +72,17 @@ describe("ActivityDemandDirector", () => {
         "(golem.runtime.capabilities=manifest-support)",
       ]),
     );
+  });
+
+  test("should throw an error if user providers a negative expirationSec value", () => {
+    expect(
+      () =>
+        new WorkloadDemandDirector(
+          new WorkloadDemandDirectorConfig({
+            imageHash: "529f7fdaf1cf46ce3126eb6bbcd3b213c314fe8fe884914f5d1106d4",
+            expirationSec: -3,
+          }),
+        ),
+    ).toThrow("The expirationSec param has to be a positive integer");
   });
 });

--- a/src/market/demand/directors/workload-demand-director.ts
+++ b/src/market/demand/directors/workload-demand-director.ts
@@ -8,6 +8,8 @@ export class WorkloadDemandDirector implements IDemandDirector {
   constructor(private config: WorkloadDemandDirectorConfig) {}
 
   public async apply(builder: DemandBodyBuilder) {
+    builder.addProperty("golem.srv.comp.expiration", Date.now() + this.config.expirationSec * 1000);
+
     builder
       .addProperty("golem.srv.comp.vm.package_format", this.config.packageFormat)
       .addConstraint("golem.runtime.name", this.config.engine);

--- a/src/resource-rental/rental.module.ts
+++ b/src/resource-rental/rental.module.ts
@@ -20,7 +20,7 @@ export interface RentalModule {
   createResourceRentalPool(
     draftPool: DraftOfferProposalPool,
     allocation: Allocation,
-    options?: ResourceRentalPoolOptions,
+    options: ResourceRentalPoolOptions,
   ): ResourceRentalPool;
 }
 

--- a/src/shared/yagna/adapters/market-api-adapter.test.ts
+++ b/src/shared/yagna/adapters/market-api-adapter.test.ts
@@ -75,7 +75,7 @@ describe("Market API Adapter", () => {
 
   describe("publishDemandSpecification()", () => {
     it("should publish a demand", async () => {
-      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform", 60 * 60 * 1000);
+      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform");
 
       when(mockMarket.subscribeDemand(deepEqual(expectedBody))).thenResolve("demand-id");
 
@@ -88,7 +88,7 @@ describe("Market API Adapter", () => {
     });
 
     it("should throw an error if the demand is not published", async () => {
-      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform", 60 * 60 * 1000);
+      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform");
 
       when(mockMarket.subscribeDemand(deepEqual(expectedBody))).thenResolve({
         message: "error publishing demand",
@@ -102,10 +102,7 @@ describe("Market API Adapter", () => {
 
   describe("unpublishDemand()", () => {
     it("should unpublish a demand", async () => {
-      const demand = new Demand(
-        "demand-id",
-        new DemandSpecification(samplePrototype, "my-selected-payment-platform", 60 * 60 * 1000),
-      );
+      const demand = new Demand("demand-id", new DemandSpecification(samplePrototype, "my-selected-payment-platform"));
 
       when(mockMarket.unsubscribeDemand("demand-id")).thenResolve({});
 
@@ -115,10 +112,7 @@ describe("Market API Adapter", () => {
     });
 
     it("should throw an error if the demand is not unpublished", async () => {
-      const demand = new Demand(
-        "demand-id",
-        new DemandSpecification(samplePrototype, "my-selected-payment-platform", 60 * 60 * 1000),
-      );
+      const demand = new Demand("demand-id", new DemandSpecification(samplePrototype, "my-selected-payment-platform"));
 
       when(mockMarket.unsubscribeDemand("demand-id")).thenResolve({
         message: "error unpublishing demand",
@@ -132,7 +126,7 @@ describe("Market API Adapter", () => {
 
   describe("counterProposal()", () => {
     it("should negotiate a proposal with the selected payment platform", async () => {
-      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform", 60 * 60 * 1000);
+      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform");
 
       const receivedProposal = new OfferProposal(
         {
@@ -172,7 +166,7 @@ describe("Market API Adapter", () => {
       ).once();
     });
     it("should throw an error if the counter proposal fails", async () => {
-      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform", 60 * 60 * 1000);
+      const specification = new DemandSpecification(samplePrototype, "my-selected-payment-platform");
       const receivedProposal = new OfferProposal(
         {
           ...expectedBody,

--- a/tests/e2e/resourceRentalPool.spec.ts
+++ b/tests/e2e/resourceRentalPool.spec.ts
@@ -29,6 +29,13 @@ describe("ResourceRentalPool", () => {
           imageTag: "golem/alpine:latest",
         },
       },
+      {
+        rentHours: 1,
+        pricing: {
+          model: "burn-rate",
+          avgGlmPerHour: 1,
+        },
+      },
       allocation,
     );
 


### PR DESCRIPTION
…r-offers and agreements

## Changed

* added MarketModuleOptions, and allowed configuring demandRefreshIntervalSec
* switched publishAndRefresh demand to use this setting instead of the expiry time of the demand (deprecated and can be removed)
* the `golem.srv.comp.expiration` property of the agreement offer is now set by the workload director and not the basic director
* the allocation is now created with +15min more expiry time than the market order itself

## Fixed

* fixed the issue where we fail to accept the invoice for an agreement that was terminated due to expiry with an allocation that expired together with the agreement (change: the allocation expiry time is set to +15 minutes more than the configured rental duration)