### PR TITLE
fix(market): proposals are now estimated with 1h duration by default

### DIFF
--- a/src/market/proposal/offer-proposal.ts
+++ b/src/market/proposal/offer-proposal.ts
@@ -98,10 +98,14 @@ export class OfferProposal extends MarketProposal {
 
   /**
    * Proposal cost estimation based on CPU, Env and startup costs
+   *
+   * @param rentHours Number of hours of rental to use for the estimation
    */
-  getEstimatedCost(): number {
-    const threadsNo = this.properties["golem.inf.cpu.threads"] || 1;
-    return this.pricing.start + this.pricing.cpuSec * threadsNo + this.pricing.envSec;
+  getEstimatedCost(rentHours = 1): number {
+    const threadsNo = this.properties["golem.inf.cpu.threads"] ?? 1;
+    const rentSeconds = rentHours * 60 * 60;
+
+    return this.pricing.start + this.pricing.cpuSec * threadsNo * rentSeconds + this.pricing.envSec * rentSeconds;
   }
 
   public get provider(): ProviderInfo {


### PR DESCRIPTION
# Changed

Adjust the code in the OfferProposal.getEstimate to handle optional parameter of rentHours (default 1) and will use this to provide the estimation