### PR TITLE
fix: add missing conditional export for browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "browser": "./dist/golem-js.min.js",
       "import": "./dist/golem-js.mjs",
       "require": "./dist/golem-js.js"
     },
     "./experimental": {
       "types": "./dist/experimental.d.ts",
+      "browser": null,
       "import": "./dist/golem-js-experimental.mjs",
       "require": "./dist/golem-js-experimental.js"
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "require": "./dist/golem-js.js"
     },
     "./experimental": {
-      "types": "./dist/experimental.d.ts",
+      "types": "./dist/experimental/index.d.ts",
       "browser": null,
       "import": "./dist/golem-js-experimental.mjs",
       "require": "./dist/golem-js-experimental.js"


### PR DESCRIPTION
1. Vite supports `browser` condition is conditional exports: https://vitejs.dev/config/shared-options#resolve-conditions
2. `"browser" : null` disallows importing from `/experimental` in the browser (we don't create a build for it anyway, so this is not a new change, more of a formality)
3. (unrelated bugfix but I might as well add it here) the file `experimental.d.ts` no longer exists because we moved the file structure and didn't update this export, so I updated it to use the correct `experimental/index.d.ts`