### PR TITLE
Grisha/developer experience improvements 24.07.11

### DIFF
--- a/src/activity/exe-script-executor.ts
+++ b/src/activity/exe-script-executor.ts
@@ -65,7 +65,7 @@ export class ExeScriptExecutor {
       const batchId = await this.send(script);
       const batchSize = JSON.parse(script.text).length;
 
-      this.logger.debug(`Script sent.`, { batchId });
+      this.logger.debug(`Script sent.`, { batchId, script });
       return { batchId, batchSize };
     } catch (error) {
       const message = getMessageFromApiError(error);
@@ -235,7 +235,7 @@ export class ExeScriptExecutor {
   private parseEventToResult(event: StreamingBatchEvent, batchSize: number): Result {
     // StreamingBatchEvent has a slightly more extensive structure,
     // including a return code that could be added to the Result entity... (?)
-    return new Result({
+    const result = new Result({
       index: event.index,
       eventDate: event.timestamp,
       result: event?.kind?.finished
@@ -250,5 +250,9 @@ export class ExeScriptExecutor {
       message: event?.kind?.finished?.message,
       isBatchFinished: event.index + 1 >= batchSize && Boolean(event?.kind?.finished),
     });
+
+    this.logger.debug("Received stream batch execution result", { result });
+
+    return result;
   }
 }

--- a/src/activity/exe-unit/batch.ts
+++ b/src/activity/exe-unit/batch.ts
@@ -109,7 +109,7 @@ export class Batch {
                     this.executor.activity.agreement.provider,
                     error,
                   );
-            this.logger.debug("Error in batch script execution");
+            this.logger.debug("Error in batch script execution", { error });
             this.script
               .after(allResults)
               .then(() => reject(golemError))

--- a/src/activity/exe-unit/process.ts
+++ b/src/activity/exe-unit/process.ts
@@ -95,4 +95,11 @@ export class RemoteProcess {
       this.subscription.add(() => end());
     });
   }
+
+  /**
+   * Checks if the exe-script batch from Yagna has completed, reflecting all work and streaming to be completed
+   */
+  isFinished() {
+    return this.lastResult?.isBatchFinished ?? false;
+  }
 }

--- a/src/shared/yagna/yagnaApi.ts
+++ b/src/shared/yagna/yagnaApi.ts
@@ -135,6 +135,7 @@ export class YagnaApi {
 
             eventSource.addEventListener("runtime", (event) => observer.next(JSON.parse(event.data)));
             eventSource.addEventListener("error", (error) => observer.error(error));
+
             return () => eventSource.close();
           });
         },
@@ -155,7 +156,7 @@ export class YagnaApi {
 
     this.gsb = gsbClient.requestor;
 
-    this.logger = options?.logger ?? defaultLogger("yagna");
+    this.logger = options?.logger ? options.logger.child("yagna") : defaultLogger("yagna");
 
     const identityClient = new YaTsClient.IdentityApi.Client({
       BASE: this.basePath,


### PR DESCRIPTION
This PR introduces fixes to logs that were needed to troubleshoot streaming batch results to the user.

I've also added the feature helping to wait for the `RemoteProcess` to reach "finished" state when the underlying exe-batch result is finished.

Allows such use-cases:

```ts
// Wait for the process to exit
await waitFor(() => proc.isFinished(), {
  abortSignal: abort.signal,
});
```