### PR TITLE
fix(resource-rental): fixed error handling when creating an exe-unit

### DIFF
--- a/src/resource-rental/resource-rental.ts
+++ b/src/resource-rental/resource-rental.ts
@@ -53,7 +53,9 @@ export class ResourceRental {
   ) {
     this.networkNode = this.resourceRentalOptions?.networkNode;
 
-    this.createExeUnit(this.abortController.signal).catch(() => null);
+    this.createExeUnit(this.abortController.signal).catch((error) =>
+      this.logger.debug(`Failed to automatically create the exe unit during resource rental initialization`, { error }),
+    );
     // TODO: Listen to agreement events to know when it goes down due to provider closing it!
   }
 

--- a/src/resource-rental/resource-rental.ts
+++ b/src/resource-rental/resource-rental.ts
@@ -53,7 +53,10 @@ export class ResourceRental {
   ) {
     this.networkNode = this.resourceRentalOptions?.networkNode;
 
-    this.createExeUnit(this.abortController.signal);
+    this.createExeUnit(this.abortController.signal).catch((error) => {
+      this.events.emit("error", error);
+      this.logger.error(`Failed to create exe-unit. ${error}`, { agreementId: this.agreement.id });
+    });
     // TODO: Listen to agreement events to know when it goes down due to provider closing it!
   }
 
@@ -181,15 +184,9 @@ export class ResourceRental {
         });
         this.events.emit("exeUnitCreated", activity);
         return this.currentExeUnit;
-      })()
-        .catch((error) => {
-          this.events.emit("error", error);
-          this.logger.error(`Failed to create exe-unit. ${error}`, { agreementId: this.agreement.id });
-          throw error;
-        })
-        .finally(() => {
-          this.exeUnitPromise = undefined;
-        });
+      })().finally(() => {
+        this.exeUnitPromise = undefined;
+      });
     }
     return this.exeUnitPromise;
   }

--- a/src/resource-rental/resource-rental.ts
+++ b/src/resource-rental/resource-rental.ts
@@ -53,10 +53,7 @@ export class ResourceRental {
   ) {
     this.networkNode = this.resourceRentalOptions?.networkNode;
 
-    this.createExeUnit(this.abortController.signal).catch((error) => {
-      this.events.emit("error", error);
-      this.logger.error(`Failed to create exe-unit. ${error}`, { agreementId: this.agreement.id });
-    });
+    this.createExeUnit(this.abortController.signal).catch(() => null);
     // TODO: Listen to agreement events to know when it goes down due to provider closing it!
   }
 
@@ -184,9 +181,15 @@ export class ResourceRental {
         });
         this.events.emit("exeUnitCreated", activity);
         return this.currentExeUnit;
-      })().finally(() => {
-        this.exeUnitPromise = undefined;
-      });
+      })()
+        .catch((error) => {
+          this.events.emit("error", error);
+          this.logger.error(`Failed to create exe-unit. ${error}`, { agreementId: this.agreement.id });
+          throw error;
+        })
+        .finally(() => {
+          this.exeUnitPromise = undefined;
+        });
     }
     return this.exeUnitPromise;
   }


### PR DESCRIPTION
This unhandled promise caused unhandled rejection if the signal was aborted before `getExeUnit()` was executed. I added `null` for the catch because another catch will handle logging and triggering the error event. However, error propagation should only take place if this method is called via `getExeUnit()`. Automatic creation of exe-unit from the constructor should ignore the error.