### PR TITLE
JST-1022: Create activities independently

### DIFF
--- a/examples/rental-model/basic/many-of.ts
+++ b/examples/rental-model/basic/many-of.ts
@@ -17,9 +17,6 @@ const order: MarketOrderSpec = {
       maxCpuPerHourPrice: 1.0,
       maxEnvPerHourPrice: 0.5,
     },
-    offerProposalFilter: (offer) => {
-      return offer.provider.name === "q53.h";
-    },
   },
 };
 

--- a/examples/rental-model/basic/many-of.ts
+++ b/examples/rental-model/basic/many-of.ts
@@ -17,6 +17,9 @@ const order: MarketOrderSpec = {
       maxCpuPerHourPrice: 1.0,
       maxEnvPerHourPrice: 0.5,
     },
+    offerProposalFilter: (offer) => {
+      return offer.provider.name === "q53.h";
+    },
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "examples/"
       ],
       "dependencies": {
-        "@rollup/rollup-win32-x64-msvc": "^4",
         "async-lock": "^1.4.1",
         "async-retry": "^1.3.3",
         "axios": "^1.6.7",

--- a/src/experimental/job/job.ts
+++ b/src/experimental/job/job.ts
@@ -145,7 +145,8 @@ export class Job<Output = unknown> {
       }
 
       signal.addEventListener("abort", () => this.events.emit("canceled"), { once: true });
-      return workOnGolem(exeUnit);
+      // remember to `await` here so that the `finally` block is executed AFTER the work is done
+      return await workOnGolem(exeUnit);
     } finally {
       await rental.stopAndFinalize();
     }

--- a/src/market/draft-offer-proposal-pool.test.ts
+++ b/src/market/draft-offer-proposal-pool.test.ts
@@ -1,7 +1,6 @@
 import { DraftOfferProposalPool } from "./draft-offer-proposal-pool";
 import { instance, mock, when } from "@johanblumenberg/ts-mockito";
 import { OfferProposal } from "./index";
-import { GolemAbortError, GolemTimeoutError } from "../shared/error/golem-error";
 
 describe("Draft Offer Proposal Pool", () => {
   // GIVEN
@@ -111,15 +110,13 @@ describe("Draft Offer Proposal Pool", () => {
     describe("Negative cases", () => {
       it("should abort the acquiring proposal by timeout", async () => {
         const pool = new DraftOfferProposalPool();
-        await expect(pool.acquire(1)).rejects.toThrow(new GolemTimeoutError("Could not provide any proposal in time"));
+        await expect(pool.acquire(1)).rejects.toThrow("The operation was aborted due to timeout");
       });
       it("should abort the acquiring proposal by signal", async () => {
         const pool = new DraftOfferProposalPool();
         const ac = new AbortController();
         ac.abort();
-        await expect(pool.acquire(ac.signal)).rejects.toThrow(
-          new GolemAbortError("The acquiring of proposals has been aborted"),
-        );
+        await expect(pool.acquire(ac.signal)).rejects.toThrow("This operation was aborted");
       });
     });
   });

--- a/src/market/market.module.test.ts
+++ b/src/market/market.module.test.ts
@@ -441,7 +441,6 @@ describe("Market module", () => {
       const goodProposal = {} as OfferProposal;
       const mockPool = mock(DraftOfferProposalPool);
       when(mockPool.acquire(_)).thenResolve(badProposal0).thenResolve(badProposal1).thenResolve(goodProposal);
-      when(mockPool.remove(_)).thenResolve();
       const goodAgreement = {} as Agreement;
       const marketSpy = spy(marketModule);
       when(marketSpy.proposeAgreement(goodProposal, _)).thenResolve(goodAgreement);
@@ -490,7 +489,6 @@ describe("Market module", () => {
     it("should abort after a set timeout", async () => {
       const mockPool = mock(DraftOfferProposalPool);
       when(mockPool.acquire()).thenResolve({} as OfferProposal);
-      when(mockPool.remove(_)).thenResolve();
       const marketSpy = spy(marketModule);
       when(marketSpy.proposeAgreement(_)).thenReject(new Error("Failed to sign proposal"));
 

--- a/src/resource-rental/resource-rental-pool.test.ts
+++ b/src/resource-rental/resource-rental-pool.test.ts
@@ -393,8 +393,12 @@ describe("ResourceRentalPool", () => {
           throw new Error("Acquire resolved even though it should have been rejected");
         })
         .catch((error) => {
-          expect(error).toBe("The pool is in draining mode");
+          expect(error).toEqual("The pool is in draining mode");
         });
+
+      // flush the promise queue to make sure the acquire promise is created
+      await new Promise(setImmediate);
+
       await pool.drainAndClear();
       await acquirePromise;
       expect(pool.getSize()).toBe(0);

--- a/src/resource-rental/resource-rental-pool.test.ts
+++ b/src/resource-rental/resource-rental-pool.test.ts
@@ -164,12 +164,12 @@ describe("ResourceRentalPool", () => {
       const acquiredRentalPromise = pool.acquire();
       // go to the next tick
       await Promise.resolve();
-      expect(pool["acquireQueue"].length).toBe(1);
+      expect(pool["acquireQueue"].size()).toBe(1);
       pool.release(acquiredRental1);
       await acquiredRentalPromise;
       expect(pool.getAvailableSize()).toBe(0);
       expect(pool.getBorrowedSize()).toBe(3);
-      expect(pool["acquireQueue"].length).toBe(0);
+      expect(pool["acquireQueue"].size()).toBe(0);
     });
     it("validates the resource rental before returning it", async () => {
       const pool = getRentalPool({ min: 3 });
@@ -214,7 +214,7 @@ describe("ResourceRentalPool", () => {
       expect(pool.getSize()).toBe(3);
       expect(pool.getBorrowedSize()).toBe(3);
       expect(pool.getAvailableSize()).toBe(0);
-      expect(pool["acquireQueue"].length).toBe(4);
+      expect(pool["acquireQueue"].size()).toBe(4);
     });
   });
   describe("release()", () => {

--- a/src/shared/utils/acquireQueue.ts
+++ b/src/shared/utils/acquireQueue.ts
@@ -40,6 +40,7 @@ export class AcquireQueue<T> {
    */
   public async get(signalOrTimeout?: number | AbortSignal): Promise<T> {
     const signal = anyAbortSignal(createAbortSignalFromTimeout(signalOrTimeout), this.abortController.signal);
+    signal.throwIfAborted();
     const { resolve, promise } = withResolvers<T>();
     this.queue.push(resolve);
 

--- a/src/shared/utils/acquireQueue.ts
+++ b/src/shared/utils/acquireQueue.ts
@@ -1,0 +1,77 @@
+import { GolemInternalError } from "../error/golem-error";
+import { anyAbortSignal, createAbortSignalFromTimeout } from "./abortSignal";
+
+/**
+ * `Promise.withResolvers` is only available in Node 22.0.0 and later.
+ */
+function withResolvers<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return { resolve, reject, promise };
+}
+
+type Acquire<T> = (item: T) => void;
+
+/**
+ * A queue of acquirers waiting for an item.
+ * use `get` to queue up for the next available item.
+ * use `put` to give the item to the next acquirer.
+ */
+export class AcquireQueue<T> {
+  private queue: Acquire<T>[] = [];
+  private abortController = new AbortController();
+
+  /**
+   * Release (reject) all acquirers.
+   * Essentially this is a way to reset the queue.
+   */
+  public releaseAll() {
+    this.abortController.abort();
+    this.queue = [];
+    this.abortController = new AbortController();
+  }
+
+  /**
+   * Queue up for the next available item.
+   */
+  public async get(signalOrTimeout?: number | AbortSignal): Promise<T> {
+    const signal = anyAbortSignal(createAbortSignalFromTimeout(signalOrTimeout), this.abortController.signal);
+    const { resolve, promise } = withResolvers<T>();
+    this.queue.push(resolve);
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      signal.addEventListener("abort", () => {
+        this.queue = this.queue.filter((r) => r !== resolve);
+        reject(signal.reason);
+      });
+    });
+    return Promise.race([promise, abortPromise]);
+  }
+
+  /**
+   * Are there any acquirers waiting for an item?
+   */
+  public hasAcquirers() {
+    return this.queue.length > 0;
+  }
+
+  /**
+   * Give the item to the next acquirer.
+   * If there are no acquirers, throw an error. You should check `hasAcquirers` before calling this method.
+   */
+  public put(item: T) {
+    if (!this.hasAcquirers()) {
+      throw new GolemInternalError("No acquirers waiting for the item");
+    }
+    const resolve = this.queue.shift()!;
+    resolve(item);
+  }
+
+  public size() {
+    return this.queue.length;
+  }
+}


### PR DESCRIPTION
The problems:
1. `DraftOfferProposalPool` uses a lock on `acquire` and `destroy`, so if someone is waiting for an offer, other offers cannot be destroyed. In the original bug after signing the first agreement we [remove the proposal from the pool after signing it](https://github.com/golemfactory/golem-js/blob/beta/src/market/market.module.ts#L560) which causes the deadlock.
2. Even with the above fixed, if we start trying to sign a new rental, there is no mechanism to stop waiting for an offer once another rental becomes available. If we run 3 tasks with only one provider, the first one gets done and the other 2 get stuck forever trying to `acquire` an offer proposal.

The solution:
1. Use the same acquire queue mechanism in `DraftOfferProposalPool` that we use in `ResourceRentalPool`. To avoid code duplication, I moved the logic of queuing and distributing items to a separate entity
2. When no rentals are available, try to sign a new one AND queue up for a released one at the same time. In the scenario where there are no proposals left in the pool, but another rental is released, we can cancel signing a new rental and use the released one instead

Unrelated to the issue above: I fixed issue where jobs would end immediately after starting, because we didn't await the worker function.

Testing:
I wrote an e2e test that runs 3 tasks at the same time with only one rental in the pool. 
I also ran the e2e and examples suite on my local yagna and everything passed.
You can also test this behavior locally by modifying the `many-of` example to only use one provider:
```ts
import { GolemNetwork, MarketOrderSpec } from "@golem-sdk/golem-js";
import { pinoPrettyLogger } from "@golem-sdk/pino-logger";

const order: MarketOrderSpec = {
  demand: {
    workload: { imageTag: "golem/alpine:latest" },
  },
  market: {
    rentHours: 0.5,
    pricing: {
      model: "linear",
      maxStartPrice: 0.5,
      maxCpuPerHourPrice: 1.0,
      maxEnvPerHourPrice: 0.5,
    },
    offerProposalFilter: (offer) => {
      return offer.provider.name === "q53.h"; // <---------------------- HERE
     },
  },
};

(async () => {
  const glm = new GolemNetwork({
    logger: pinoPrettyLogger({
      level: "info",
    }),
  });

  try {
    await glm.connect();
    // create a pool that can grow up to 3 rentals at the same time
    const pool = await glm.manyOf({
      poolSize: 3,
      order,
    });
    await Promise.allSettled([
      pool.withRental(async (rental) =>
        rental
          .getExeUnit()
          .then((exe) => exe.run("echo Hello, Golem from the first machine! 👋"))
          .then((res) => console.log(res.stdout)),
      ),
      pool.withRental(async (rental) =>
        rental
          .getExeUnit()
          .then((exe) => exe.run("echo Hello, Golem from the second machine! 👋"))
          .then((res) => console.log(res.stdout)),
      ),
      pool.withRental(async (rental) =>
        rental
          .getExeUnit()
          .then((exe) => exe.run("echo Hello, Golem from the third machine! 👋"))
          .then((res) => console.log(res.stdout)),
      ),
    ]);
  } catch (err) {
    console.error("Failed to run the example", err);
  } finally {
    await glm.disconnect();
  }
})().catch(console.error);
```