### PR TITLE
feat(demand): added the ability to define runtime version as demand options

### DIFF
--- a/examples/core-api/scan.ts
+++ b/examples/core-api/scan.ts
@@ -8,7 +8,9 @@ import { last, map, scan, takeUntil, tap, timer } from "rxjs";
 const scanOptions: ScanOptions = {
   // fairly powerful machine but not too powerful
   workload: {
-    engine: "vm",
+    runtime: {
+      name: "vm",
+    },
     minCpuCores: 4,
     maxCpuCores: 16,
     minMemGib: 4,

--- a/src/market/demand/directors/workload-demand-director-config.ts
+++ b/src/market/demand/directors/workload-demand-director-config.ts
@@ -14,6 +14,10 @@ type RequiredWorkloadDemandConfigOptions = {
 export class WorkloadDemandDirectorConfig extends BaseConfig {
   readonly packageFormat: string = PackageFormat.GVMKitSquash;
   readonly engine: string = "vm";
+  readonly runtime = {
+    name: "vm",
+    version: "0.3.0",
+  };
   readonly minMemGib: number = 0.5;
   readonly minStorageGib: number = 2;
   readonly minCpuThreads: number = 1;
@@ -36,6 +40,13 @@ export class WorkloadDemandDirectorConfig extends BaseConfig {
 
     Object.assign(this, options);
 
+    if (!this.runtime.name) {
+      this.runtime.name = this.engine;
+    }
+    if (!this.runtime.version) {
+      this.runtime.version = "0.3.0";
+    }
+
     this.expirationSec = options.expirationSec;
 
     if (!this.imageHash && !this.manifest && !this.imageTag && !this.imageUrl) {
@@ -48,6 +59,12 @@ export class WorkloadDemandDirectorConfig extends BaseConfig {
 
     if (!this.isPositiveInt(this.expirationSec)) {
       throw new GolemConfigError("The expirationSec param has to be a positive integer");
+    }
+
+    if (options.engine && options.runtime) {
+      throw new GolemConfigError(
+        "The engine parameter is deprecated and cannot be used with the runtime parameter. Use the runtime option only",
+      );
     }
   }
 }

--- a/src/market/demand/directors/workload-demand-director.test.ts
+++ b/src/market/demand/directors/workload-demand-director.test.ts
@@ -85,4 +85,44 @@ describe("ActivityDemandDirector", () => {
         ),
     ).toThrow("The expirationSec param has to be a positive integer");
   });
+
+  test("should create constraints with runtime name and runtime version", async () => {
+    const builder = new DemandBodyBuilder();
+
+    const director = new WorkloadDemandDirector(
+      new WorkloadDemandDirectorConfig({
+        runtime: {
+          name: "vm-test",
+          version: "0.7.0",
+        },
+        expirationSec: 2,
+        imageHash: "529f7fdaf1cf46ce3126eb6bbcd3b213c314fe8fe884914f5d1106d4",
+      }),
+    );
+    await director.apply(builder);
+
+    const decorations = builder.getProduct();
+
+    expect(decorations.constraints).toEqual(
+      expect.arrayContaining(["(golem.runtime.name=vm-test)", "(golem.runtime.version=0.7.0)"]),
+    );
+  });
+
+  test("should throw an error if user providers a engine and runtime name", () => {
+    expect(
+      () =>
+        new WorkloadDemandDirector(
+          new WorkloadDemandDirectorConfig({
+            engine: "vm",
+            runtime: {
+              name: "vm",
+            },
+            expirationSec: 2,
+            imageHash: "529f7fdaf1cf46ce3126eb6bbcd3b213c314fe8fe884914f5d1106d4",
+          }),
+        ),
+    ).toThrow(
+      "The engine parameter is deprecated and cannot be used with the runtime parameter. Use the runtime option only",
+    );
+  });
 });

--- a/src/market/demand/directors/workload-demand-director.test.ts
+++ b/src/market/demand/directors/workload-demand-director.test.ts
@@ -108,7 +108,7 @@ describe("ActivityDemandDirector", () => {
     );
   });
 
-  test("should throw an error if user providers a engine and runtime name", () => {
+  test("should throw an error if user providers both engine and runtime.name params", () => {
     expect(
       () =>
         new WorkloadDemandDirector(

--- a/src/market/demand/directors/workload-demand-director.ts
+++ b/src/market/demand/directors/workload-demand-director.ts
@@ -12,7 +12,8 @@ export class WorkloadDemandDirector implements IDemandDirector {
 
     builder
       .addProperty("golem.srv.comp.vm.package_format", this.config.packageFormat)
-      .addConstraint("golem.runtime.name", this.config.engine);
+      .addConstraint("golem.runtime.name", this.config.runtime.name)
+      .addConstraint("golem.runtime.version", this.config.runtime.version);
 
     if (this.config.capabilities.length)
       this.config.capabilities.forEach((cap) => builder.addConstraint("golem.runtime.capabilities", cap));

--- a/src/market/demand/options.ts
+++ b/src/market/demand/options.ts
@@ -24,7 +24,15 @@ export type RuntimeDemandOptions = {
   engine: string;
 
   runtime: Partial<{
+    /**
+     * Name of the runtime supported by the provider: vm, wasm, vm-nvidia, etc...
+     * @default vm
+     * */
     name: string;
+    /**
+     * Runtime version supported by provider
+     * @default 0.3.0
+     */
     version: string;
   }>;
 

--- a/src/market/demand/options.ts
+++ b/src/market/demand/options.ts
@@ -18,8 +18,15 @@ export type ResourceDemandOptions = {
  * Specifies a set of options related to runtime configuration that will be used to form the demand
  */
 export type RuntimeDemandOptions = {
-  /** Type of engine required: vm, wasm, vm-nvidia, etc... */
+  /** Type of engine required: vm, wasm, vm-nvidia, etc...
+   * @deprecated This field is deprecated and will be removed in future versions. Please use the 'runtime.name' instead.
+   */
   engine: string;
+
+  runtime: Partial<{
+    name: string;
+    version: string;
+  }>;
 
   /** Required providers capabilities to run application: example: ["vpn"] */
   capabilities: string[];

--- a/src/market/proposal/offer-proposal.ts
+++ b/src/market/proposal/offer-proposal.ts
@@ -26,6 +26,7 @@ export type ProposalDTO = Partial<{
   publicNet: boolean;
   runtimeCapabilities: string[];
   runtimeName: string;
+  runtimeVersion: string;
   state: ProposalState;
 }>;
 
@@ -92,6 +93,7 @@ export class OfferProposal extends MarketProposal {
       publicNet: this.properties["golem.node.net.is-public"],
       runtimeCapabilities: this.properties["golem.runtime.capabilities"],
       runtimeName: this.properties["golem.runtime.name"],
+      runtimeVersion: this.properties["golem.runtime.version"],
       state: this.state,
     };
   }

--- a/src/market/scan/scan-director.ts
+++ b/src/market/scan/scan-director.ts
@@ -20,7 +20,7 @@ export class ScanDirector {
   }
 
   private addWorkloadDecorations(builder: DemandBodyBuilder): void {
-    if (this.options.workload?.engine && this.options.workload?.runtime?.name) {
+    if (this.options.workload?.engine && this.options.workload?.runtime) {
       throw new GolemConfigError(
         "The engine parameter is deprecated and cannot be used with the runtime parameter. Use the runtime parameter only",
       );

--- a/src/market/scan/scan-director.ts
+++ b/src/market/scan/scan-director.ts
@@ -1,5 +1,6 @@
 import { ComparisonOperator, DemandBodyBuilder } from "../demand";
 import { ScanOptions } from "./types";
+import { GolemConfigError } from "../../shared/error/golem-error";
 
 export class ScanDirector {
   constructor(private options: ScanOptions) {}
@@ -19,8 +20,20 @@ export class ScanDirector {
   }
 
   private addWorkloadDecorations(builder: DemandBodyBuilder): void {
+    if (this.options.workload?.engine && this.options.workload?.runtime?.name) {
+      throw new GolemConfigError(
+        "The engine parameter is deprecated and cannot be used with the runtime parameter. Use the runtime parameter only",
+      );
+    }
+    /** @deprecated  */
     if (this.options.workload?.engine) {
       builder.addConstraint("golem.runtime.name", this.options.workload?.engine);
+    }
+    if (this.options.workload?.runtime?.name) {
+      builder.addConstraint("golem.runtime.name", this.options.workload.runtime.name);
+    }
+    if (this.options.workload?.runtime?.version) {
+      builder.addConstraint("golem.runtime.version", this.options.workload.runtime.version);
     }
     if (this.options.workload?.capabilities)
       this.options.workload?.capabilities.forEach((cap) => builder.addConstraint("golem.runtime.capabilities", cap));

--- a/src/market/scan/scanned-offer.ts
+++ b/src/market/scan/scanned-offer.ts
@@ -115,6 +115,10 @@ export class ScannedOffer {
     return this.properties["golem.runtime.name"];
   }
 
+  get runtimeVersion() {
+    return this.properties["golem.runtime.version"];
+  }
+
   /**
    * Get the ID of the offer published by the Provider
    *

--- a/src/market/scan/types.ts
+++ b/src/market/scan/types.ts
@@ -1,6 +1,13 @@
 export type ScanOptions = {
   workload?: {
+    /**
+     * @deprecated This param is deprecated and will be removed in future versions. Please use the 'runtime.name' instead.
+     */
     engine?: string;
+    runtime?: {
+      name?: string;
+      version?: string;
+    };
     capabilities?: string[];
     minMemGib?: number;
     maxMemGib?: number;


### PR DESCRIPTION
The previous `engine` parameter has been marked as deprecated and will be replaced by `runtime.name` in the next versions