### PR TITLE
feat(market): added getEstimatedCost to ScannedOffer

### DIFF
--- a/src/market/proposal/offer-proposal.ts
+++ b/src/market/proposal/offer-proposal.ts
@@ -99,12 +99,12 @@ export class OfferProposal extends MarketProposal {
   }
 
   /**
-   * Proposal cost estimation based on CPU, Env and startup costs
+   * Cost estimation based on CPU/h, ENV/h and start prices
    *
    * @param rentHours Number of hours of rental to use for the estimation
    */
   getEstimatedCost(rentHours = 1): number {
-    const threadsNo = this.properties["golem.inf.cpu.threads"] ?? 1;
+    const threadsNo = this.getDto().cpuThreads ?? 1;
     const rentSeconds = rentHours * 60 * 60;
 
     return this.pricing.start + this.pricing.cpuSec * threadsNo * rentSeconds + this.pricing.envSec * rentSeconds;

--- a/src/market/scan/scanned-offer.test.ts
+++ b/src/market/scan/scanned-offer.test.ts
@@ -19,4 +19,35 @@ describe("Scanned Offer", () => {
     expect(offer.paymentPlatformAddresses["erc20-holesky-tglm"]).toEqual("0xHoleskyAddress");
     expect(Object.entries(offer.paymentPlatformAddresses).length).toEqual(2);
   });
+
+  test("Provides API to get cost estimate", () => {
+    const durationHours = 1;
+
+    const hr2Sec = (hours: number) => hours * 60 * 60;
+
+    const numThreads = 4;
+    const startPrice = 0.3;
+    const envPerSec = 0.2;
+    const cpuPerSec = 0.1;
+
+    const offer = new ScannedOffer({
+      offerId: "example-id",
+      properties: {
+        "golem.com.payment.platform.erc20-polygon-glm.address": "0xPolygonAddress",
+        "golem.com.payment.platform.erc20-holesky-tglm.address": "0xHoleskyAddress",
+        "golem.com.payment.platform.nonsense": "0xNonsense",
+        "golem.com.usage.vector": ["golem.usage.cpu_sec", "golem.usage.duration_sec"],
+        "golem.com.pricing.model.linear.coeffs": [cpuPerSec, envPerSec, startPrice],
+        "golem.inf.cpu.threads": numThreads,
+        "some.other.prop": "with-a-value",
+      },
+      timestamp: new Date().toISOString(),
+      providerId: "provider-id",
+      constraints: "",
+    });
+
+    expect(offer.getEstimatedCost(durationHours)).toEqual(
+      startPrice + numThreads * hr2Sec(durationHours) * cpuPerSec + hr2Sec(durationHours) * envPerSec,
+    );
+  });
 });

--- a/src/market/scan/scanned-offer.ts
+++ b/src/market/scan/scanned-offer.ts
@@ -160,4 +160,16 @@ export class ScannedOffer {
 
     return Object.fromEntries(platformAddress);
   }
+
+  /**
+   * Cost estimation based on CPU/h, ENV/h and start prices
+   *
+   * @param rentHours Number of hours of rental to use for the estimation
+   */
+  public getEstimatedCost(rentHours = 1): number {
+    const threadsNo = this.cpuThreads;
+    const rentSeconds = rentHours * 60 * 60;
+
+    return this.pricing.start + this.pricing.cpuSec * threadsNo * rentSeconds + this.pricing.envSec * rentSeconds;
+  }
 }


### PR DESCRIPTION
This PR adds the feature of estimating the scanned offer cost by the SDK, so that users (the CLI) won't have to do it on its own