### PR TITLE
test: changed the way of reacting to the end of the test and adding timeout clearing

### DIFF
--- a/tests/examples/examples.test.ts
+++ b/tests/examples/examples.test.ts
@@ -47,9 +47,10 @@ async function test(cmd: string, path: string, args: string[] = [], timeout = 36
     };
     spawnedExample.stdout?.on("data", assertLogs);
     spawnedExample.stderr?.on("data", assertLogs);
-    spawnedExample.on("close", (code) => {
+    spawnedExample.on("exit", (code, siganl) => {
+      clearTimeout(timeoutId);
       if (!error && !code) return res(true);
-      rej(`Test example "${file}" failed. ${error}`);
+      rej(`Test example "${file}" failed. Exited with code ${code} by signal ${siganl}. ${error}`);
     });
   }).finally(() => {
     clearTimeout(timeoutId);


### PR DESCRIPTION
With these changes, looped tests for 6 hours did not cause any errors. The only difference is in the way of listening for the end of the spawned process. `onClose` waits for the bound stdio to end. `onExit` does not wait for the stdio to close. Perhaps in some unspecified cases stdio are not closed and despite the process ending we do not react to it. 
Additionally, I added clearing the timeout.