### PR TITLE
fix: update reputation url

### DIFF
--- a/src/experimental/reputation/system.ts
+++ b/src/experimental/reputation/system.ts
@@ -44,7 +44,7 @@ export const DEFAULT_AGREEMENT_WEIGHTS: ReputationWeights = {
  * Default reputation service URL.
  * @experimental
  */
-export const DEFAULT_REPUTATION_URL = "https://reputation.dev-test.golem.network/v2/providers/scores";
+export const DEFAULT_REPUTATION_URL = "https://reputation.golem.network/v2/providers/scores";
 
 /**
  * The number of top scoring providers to consider when selecting an agreement.

--- a/src/market/helpers.ts
+++ b/src/market/helpers.ts
@@ -9,7 +9,7 @@ import { GolemInternalError } from "../shared/error/golem-error";
  */
 export async function getHealthyProvidersWhiteList(): Promise<string[]> {
   try {
-    const response = await fetch("https://reputation.dev-test.golem.network/v1/provider-whitelist");
+    const response = await fetch("https://reputation.golem.network/v1/provider-whitelist");
 
     if (response.ok) {
       return response.json();


### PR DESCRIPTION
The dev-test domains will be removed at the end of the month, and we've moved the reputation domain to the root URL in preparation. Please merge this to ensure your code works with the new URL moving forward.