### PR TITLE
feat: added experimental volume support for golem-js

### DIFF
--- a/src/activity/script/command.ts
+++ b/src/activity/script/command.ts
@@ -59,8 +59,32 @@ export class Command<T = unknown> {
   }
 }
 
+export type DeployArgs = {
+  net?: DeployNetworkArgs[];
+  volumes?: DeployVolumesArgs;
+};
+
+type DeployNetworkArgs = {
+  id: string;
+  ip: string;
+  mask: string;
+  gateway?: string;
+  nodes: { [ip: string]: string };
+  nodeIp: string;
+};
+
+type DeployVolumesArgs = {
+  [path: string]: {
+    storage: {
+      /** @example 7000m */
+      size: string;
+      errors?: "panic";
+    };
+  };
+};
+
 export class Deploy extends Command {
-  constructor(args?: Record<string, unknown>) {
+  constructor(args?: DeployArgs) {
     super("deploy", args);
   }
 }

--- a/src/network/node.ts
+++ b/src/network/node.ts
@@ -1,4 +1,5 @@
 import { NetworkInfo } from "./network";
+import { DeployArgs } from "../activity/script/command";
 
 /**
  * Describes a node in a VPN, mapping a Golem node id to an IP address
@@ -13,10 +14,10 @@ export class NetworkNode {
 
   /**
    * Generate a dictionary of arguments that are required for the appropriate
-   *`Deploy` command of an exescript in order to pass the network configuration to the runtime
+   *`Deploy` command of an exe-script in order to pass the network configuration to the runtime
    * on the provider's end.
    */
-  getNetworkConfig() {
+  getNetworkDeploymentArg(): Pick<DeployArgs, "net"> {
     return {
       net: [
         {

--- a/src/resource-rental/resource-rental.ts
+++ b/src/resource-rental/resource-rental.ts
@@ -24,7 +24,7 @@ export interface ResourceRentalEvents {
 }
 
 export interface ResourceRentalOptions {
-  exeUnit?: Pick<ExeUnitOptions, "setup" | "teardown" | "activityDeployingTimeout">;
+  exeUnit?: Pick<ExeUnitOptions, "setup" | "teardown" | "activityDeployingTimeout" | "volumes">;
   activity?: ExecutionOptions;
   payment?: Partial<PaymentProcessOptions>;
   networkNode?: NetworkNode;


### PR DESCRIPTION
## Why?

The deployment-time volume definition parameter is introduced in exe-unit 0.5.2 and yagna 0.17. This PR adds the API access to that feature. It's marked as experimental because of the yagna 0.17 development status (RC right now).

## Example

```ts
import {GolemNetwork} from "../src";

(async () => {
  const glm = new GolemNetwork({
    payment:{
      network: "holesky"
    }
  });

  try {
    console.log("Connecting to Golem Network")
    await glm.connect();

    console.log("Acquiring resources from the market")
    const rental = await glm.oneOf({
      order: {
        demand: {
          workload: {
            imageTag: "golem/node:latest",
            minStorageGib: 1,
            runtime: {
              version: "0.5.2"
            }
          }
        },
        market: {
          rentHours: 15/60,
          pricing: {
            avgGlmPerHour: 1,
            model: "burn-rate"
          },
        }
      },
      volumes: {
        data: {
          path: "/custom-data",
          sizeGib: 1
        },
        files: {
          path: "/custom-files",
          sizeGib: 1
        }
      }
    })

    console.log("Deployng workload to the rental")
    const exe = await rental.getExeUnit();

    console.log("Running command on the workload")
    const result = await exe.run("df -h");
    console.log(result.stdout?.toString());

    console.log("Finalizing the rental and releasing resources to the market")
    await rental.stopAndFinalize();
  }
  finally {
    await glm.disconnect();
  }
})().catch(console.error);
```