### PR TITLE
fix(exe-unit): fixed setup timeout shutting down the internal executor regardless of success

### DIFF
--- a/src/activity/activity.module.ts
+++ b/src/activity/activity.module.ts
@@ -301,7 +301,7 @@ export class ActivityModuleImpl implements ActivityModule {
     this.logger.debug("Initializing the exe-unit for activity", { activityId: activity.id });
 
     try {
-      await exe.setup();
+      await exe.setup(options?.setupSignalOrTimeout);
       const refreshedActivity = await this.refreshActivity(activity).catch(() => {
         this.logger.warn("Failed to refresh activity after work context initialization", { activityId: activity.id });
         return activity;

--- a/src/resource-rental/resource-rental.ts
+++ b/src/resource-rental/resource-rental.ts
@@ -194,7 +194,8 @@ export class ResourceRental {
           storageProvider: this.storageProvider,
           networkNode: this.resourceRentalOptions?.networkNode,
           executionOptions: this.resourceRentalOptions?.activity,
-          signalOrTimeout: abortSignal,
+          signalOrTimeout: this.finalizeAbortController.signal,
+          setupSignalOrTimeout: this.setupAbortController.signal,
           ...this.resourceRentalOptions?.exeUnit,
         });
         this.events.emit("exeUnitCreated", activity);


### PR DESCRIPTION
Providing a timeout to `getExeUnit` would incorrectly shut down the internal executor after the specified time even if the activity deployed correctly, which would in turn shut down the whole exe-unit. This is now fixed